### PR TITLE
[aci_epg_to_static_path] force existing 'aci_epg_to_static_path' to be recreated when 'tdn' changed. fix#135

### DIFF
--- a/aci/resource_aci_fvrspathatt.go
+++ b/aci/resource_aci_fvrspathatt.go
@@ -27,11 +27,13 @@ func resourceAciStaticPath() *schema.Resource {
 			"application_epg_dn": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 
 			"tdn": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 
 			"encap": &schema.Schema{

--- a/examples/aci_epg_to_static_path/aci_epg_to_static_path.tf
+++ b/examples/aci_epg_to_static_path/aci_epg_to_static_path.tf
@@ -1,0 +1,21 @@
+resource "aci_tenant" "terraform_tenant" {
+    name        = "tf_tenant"
+    description = "This tenant is created by terraform"
+}
+
+resource "aci_application_profile" "terraform_ap" {
+    tenant_dn  = aci_tenant.terraform_tenant.id
+    name       = "tf_ap"
+}
+
+resource "aci_application_epg" "terraform_epg" {
+    application_profile_dn  = aci_application_profile.terraform_ap.id
+    name                    = "tf_epg"
+}
+
+resource "aci_epg_to_static_path" "example" {
+    application_epg_dn  = aci_application_epg.terraform_epg.id
+    tdn  = "topology/pod-1/paths-129/pathep-[eth1/5]"
+    encap  = "vlan-100"
+    mode  = "regular"
+}

--- a/examples/aci_epg_to_static_path/main.tf
+++ b/examples/aci_epg_to_static_path/main.tf
@@ -1,0 +1,14 @@
+provider "aci" {
+  username = ""
+  password = ""
+  url      = ""
+  insecure = true
+}
+
+# provider "aci" {
+#   username    = ""
+#   private_key = ""
+#   cert_name   = ""
+#   url         = ""
+#   insecure    = true
+# }

--- a/website/docs/r/fvrspathatt.html.markdown
+++ b/website/docs/r/fvrspathatt.html.markdown
@@ -13,20 +13,15 @@ Manages ACI Static Path
 
 ```hcl
 resource "aci_epg_to_static_path" "example" {
-
   application_epg_dn  = "${aci_application_epg.example.id}"
-
-  tDn  = "example"
-  annotation  = "example"
-  encap  = "example"
-  instr_imedcy  = "example"
-  mode  = "example"
-  primary_encap  = "example"
+  tdn  = "topology/pod-1/paths-129/pathep-[eth1/3]"
+  encap  = "vlan-1000"
+  mode  = "regular"
 }
 ```
 ## Argument Reference ##
 * `application_epg_dn` - (Required) Distinguished name of parent ApplicationEPG object.
-* `tDn` - (Required) tDn of Object static_path.
+* `tdn` - (Required) tDn of Object static_path.
 * `annotation` - (Optional) annotation for object static_path.
 * `encap` - (Optional) encapsulation
 * `instr_imedcy` - (Optional) immediacy.


### PR DESCRIPTION
- force 'aci_epg_to_static_path' to be recreated instead of being updated when 'tdn' changed
- provide example for resource 'aci_epg_to_static_path'

resolve #135 