### PR TITLE
https://github.com/CiscoDevNet/terraform-provider-aci/issues/164

### DIFF
--- a/aci/resource_aci_vzbrcp.go
+++ b/aci/resource_aci_vzbrcp.go
@@ -565,8 +565,16 @@ func setFilterEntryAttributesFromContract(vzentry *models.FilterEntry, d *schema
 	eMap["s_to_port"] = vzEntryMap["sToPort"]
 	eMap["stateful"] = vzEntryMap["stateful"]
 	eMap["tcp_rules"] = vzEntryMap["tcpRules"]
-	eMap["d_from_port"] = constantPortMapping[vzEntryMap["dFromPort"]]
-	eMap["d_to_port"] = constantPortMapping[vzEntryMap["dToPort"]]
+	if v, found := constantPortMapping[vzEntryMap["dFromPort"]]; found {
+		eMap["d_from_port"] = v
+	} else {
+		eMap["d_from_port"] = vzEntryMap["dFromPort"]
+	}
+	if v, found := constantPortMapping[vzEntryMap["dToPort"]]; found {
+		eMap["d_to_port"] = v
+	} else {
+		eMap["d_to_port"] = vzEntryMap["dToPort"]
+	}
 	return eMap
 }
 


### PR DESCRIPTION
Added a check for the d_from_port and d_to_port when saving the state as it was not previously saving the correct state. related issue: https://github.com/CiscoDevNet/terraform-provider-aci/issues/164