### PR TITLE
when the path, the class_name or the dn change the resource should be…

### DIFF
--- a/aci/resource_rest.go
+++ b/aci/resource_rest.go
@@ -29,12 +29,14 @@ func resourceAciRest() *schema.Resource {
 			"path": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			// we set it automatically if file config is provided
 			"class_name": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 			"content": &schema.Schema{
 				Type:     schema.TypeMap,
@@ -43,6 +45,7 @@ func resourceAciRest() *schema.Resource {
 			"dn": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
+				ForceNew: true,
 			},
 			"payload": &schema.Schema{
 				Type:     schema.TypeString,


### PR DESCRIPTION
… recreated

this fix #195 