### PR TITLE
Fixed example scripts by changing format of variable declaration. Fixes #183

### DIFF
--- a/examples/aci_node_block/main.tf
+++ b/examples/aci_node_block/main.tf
@@ -3,13 +3,13 @@ resource "aci_leaf_profile" "checkBLK" {
 }
 
 resource "aci_switch_association" "checkBLK" {
-  leaf_profile_dn  = "${aci_leaf_profile.checkBLK.id}"
+  leaf_profile_dn  = aci_leaf_profile.checkBLK.id
   name  = "example"
   switch_association_type  = "range"
 }
 
 resource "aci_node_block" "check" {
-  switch_association_dn   = "${aci_switch_association.checkBLK.id}"
+  switch_association_dn   = aci_switch_association.checkBLK.id
   name                    = "block"
   annotation              = "aci_node_block"
   from_                   = "101"

--- a/examples/aci_test/main.tf
+++ b/examples/aci_test/main.tf
@@ -10,29 +10,29 @@ resource "aci_tenant" "terraform_ten" {
 }
 
 resource "aci_vrf" "vrf1" {
-  tenant_dn = "${aci_tenant.terraform_ten.id}"
+  tenant_dn = aci_tenant.terraform_ten.id
   name      = "vrf1"
 }
 
 resource "aci_bridge_domain" "bd1" {
-  tenant_dn          = "${aci_tenant.terraform_ten.id}"
-  relation_fv_rs_ctx = "${aci_vrf.vrf1.name}"
+  tenant_dn          = aci_tenant.terraform_ten.id
+  relation_fv_rs_ctx = aci_vrf.vrf1.name
   name               = "bd1"
 }
 
 resource "aci_subnet" "bd1_subnet" {
-  bridge_domain_dn = "${aci_bridge_domain.bd1.id}"
+  bridge_domain_dn = aci_bridge_domain.bd1.id
   name             = "Subnet"
-  ip               = "${var.bd_subnet}"
+  ip               = var.bd_subnet
 }
 
 resource "aci_application_profile" "app1" {
-  tenant_dn = "${aci_tenant.terraform_ten.id}"
+  tenant_dn = aci_tenant.terraform_ten.id
   name      = "app1"
 }
 
 # resource "aci_vmm_domain" "vds" {
-#   provider_profile_dn = "${var.provider_profile_dn}"
+#   provider_profile_dn = var.provider_profile_dn
 #   name                = "ESX0-leaf102"
 # }
 
@@ -42,44 +42,44 @@ data "aci_vmm_domain" "vds" {
 }
 
 resource "aci_application_epg" "epg1" {
-  application_profile_dn = "${aci_application_profile.app1.id}"
+  application_profile_dn = aci_application_profile.app1.id
   name                   = "epg1"
-  relation_fv_rs_bd      = "${aci_bridge_domain.bd1.name}"
-  relation_fv_rs_dom_att = ["${data.aci_vmm_domain.vds.id}"]
-  relation_fv_rs_cons    = ["${aci_contract.contract_epg1_epg2.name}"]
+  relation_fv_rs_bd      = aci_bridge_domain.bd1.name
+  relation_fv_rs_dom_att = [data.aci_vmm_domain.vds.id]
+  relation_fv_rs_cons    = [aci_contract.contract_epg1_epg2.name]
 }
 
 resource "aci_application_epg" "epg2" {
-  application_profile_dn = "${aci_application_profile.app1.id}"
+  application_profile_dn = aci_application_profile.app1.id
   name                   = "epg2"
-  relation_fv_rs_bd      = "${aci_bridge_domain.bd1.name}"
-  relation_fv_rs_dom_att = ["${data.aci_vmm_domain.vds.id}"]
-  relation_fv_rs_prov    = ["${aci_contract.contract_epg1_epg2.name}"]
+  relation_fv_rs_bd      = aci_bridge_domain.bd1.name
+  relation_fv_rs_dom_att = [data.aci_vmm_domain.vds.id]
+  relation_fv_rs_prov    = [aci_contract.contract_epg1_epg2.name]
 }
 
 resource "aci_contract" "contract_epg1_epg2" {
-  tenant_dn = "${aci_tenant.terraform_ten.id}"
+  tenant_dn = aci_tenant.terraform_ten.id
   name      = "Web"
 }
 
 resource "aci_contract_subject" "Web_subject1" {
-  contract_dn                  = "${aci_contract.contract_epg1_epg2.id}"
+  contract_dn                  = aci_contract.contract_epg1_epg2.id
   name                         = "Subject"
-  relation_vz_rs_subj_filt_att = ["${aci_filter.allow_https.name}","${aci_filter.allow_icmp.name}"]
+  relation_vz_rs_subj_filt_att = [aci_filter.allow_https.name, aci_filter.allow_icmp.name]
 }
 
 resource "aci_filter" "allow_https" {
-  tenant_dn = "${aci_tenant.terraform_ten.id}"
+  tenant_dn = aci_tenant.terraform_ten.id
   name      = "allow_https"
 }
 resource "aci_filter" "allow_icmp" {
-  tenant_dn = "${aci_tenant.terraform_ten.id}"
+  tenant_dn = aci_tenant.terraform_ten.id
   name      = "allow_icmp"
 }
 
 resource "aci_filter_entry" "https" {
   name        = "https"
-  filter_dn   = "${aci_filter.allow_https.id}"
+  filter_dn   = aci_filter.allow_https.id
   ether_t     = "ip"
   prot        = "tcp"
   d_from_port = "https"
@@ -89,7 +89,7 @@ resource "aci_filter_entry" "https" {
 
 resource "aci_filter_entry" "icmp" {
   name        = "icmp"
-  filter_dn   = "${aci_filter.allow_icmp.id}"
+  filter_dn   = aci_filter.allow_icmp.id
   ether_t     = "ip"
   prot        = "icmp"
   stateful    = "yes"

--- a/examples/aci_test/vcenter.tf
+++ b/examples/aci_test/vcenter.tf
@@ -1,109 +1,109 @@
 provider "vsphere" {
-  user                 = "${var.vsphere_user}"
-  password             = "${var.vsphere_password}"
-  vsphere_server       = "${var.vsphere_server}"
+  user                 = var.vsphere_user
+  password             = var.vsphere_password
+  vsphere_server       = var.vsphere_server
   allow_unverified_ssl = true
 }
 
 data "vsphere_datacenter" "dc" {
-  name = "${var.vsphere_datacenter}"
+  name = var.vsphere_datacenter
 }
 
 data "vsphere_network" "vm1_net" {
-  name          = "${format("%v|%v|%v", aci_tenant.terraform_ten.name, aci_application_profile.app1.name, aci_application_epg.epg1.name)}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = format("%v|%v|%v", aci_tenant.terraform_ten.name, aci_application_profile.app1.name, aci_application_epg.epg1.name)
+  datacenter_id = data.vsphere_datacenter.dc.id
 }
 
 data "vsphere_network" "vm2_net" {
-  name          = "${format("%v|%v|%v", aci_tenant.terraform_ten.name, aci_application_profile.app1.name, aci_application_epg.epg2.name)}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = format("%v|%v|%v", aci_tenant.terraform_ten.name, aci_application_profile.app1.name, aci_application_epg.epg2.name)
+  datacenter_id = data.vsphere_datacenter.dc.id
 }
 
 data "vsphere_datastore" "ds" {
-  name          = "${var.vsphere_datastore}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = var.vsphere_datastore
+  datacenter_id = data.vsphere_datacenter.dc.id
 }
 
 # data "vsphere_compute_cluster" "cl" {
-#   name          = "${var.vsphere_compute_cluster}"
-#   datacenter_id = "${data.vsphere_datacenter.dc.id}"
+#   name          = var.vsphere_compute_cluster
+#   datacenter_id = data.vsphere_datacenter.dc.id
 # }
 
 data "vsphere_host" "host" {
-  name          = "${var.vsphere_host_name}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = var.vsphere_host_name
+  datacenter_id = data.vsphere_datacenter.dc.id
 }
 
 data "vsphere_virtual_machine" "template" {
-  name          = "${var.vsphere_template}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = var.vsphere_template
+  datacenter_id = data.vsphere_datacenter.dc.id
 }
 
 resource "vsphere_virtual_machine" "aci_vm1" {
   count        = 1
-  name         = "${var.aci_vm1_name}"
-  datastore_id = "${data.vsphere_datastore.ds.id}"
+  name         = var.aci_vm1_name
+  datastore_id = data.vsphere_datastore.ds.id
 
   num_cpus = 2
   memory   = 4096
-  guest_id = "${data.vsphere_virtual_machine.template.guest_id}"
+  guest_id = data.vsphere_virtual_machine.template.guest_id
 
-  #   resource_pool_id = "${data.vsphere_compute_cluster.cl.resource_pool_id}"
+  #   resource_pool_id = data.vsphere_compute_cluster.cl.resource_pool_id
 
-  resource_pool_id = "${data.vsphere_host.host.resource_pool_id}"
-  scsi_type = "${data.vsphere_virtual_machine.template.scsi_type}"
+  resource_pool_id = data.vsphere_host.host.resource_pool_id
+  scsi_type = data.vsphere_virtual_machine.template.scsi_type
   disk {
     label = "disk0"
-    size  = "${data.vsphere_virtual_machine.template.disks.0.size}"
+    size  = data.vsphere_virtual_machine.template.disks.0.size
   }
   disk {
     unit_number = 1
     label       = "disk1"
     size        = 40
   }
-  folder = "${var.folder}"
+  folder = var.folder
   network_interface {
-    network_id   = "${data.vsphere_network.vm1_net.id}"
-    adapter_type = "${data.vsphere_virtual_machine.template.network_interface_types[0]}"
+    network_id   = data.vsphere_network.vm1_net.id
+    adapter_type = data.vsphere_virtual_machine.template.network_interface_types[0]
   }
   clone {
-    template_uuid = "${data.vsphere_virtual_machine.template.id}"
+    template_uuid = data.vsphere_virtual_machine.template.id
     linked_clone  = true
     customize {
       linux_options {
-        host_name = "${var.aci_vm1_name}"
-        domain    = "${var.domain_name}"
+        host_name = var.aci_vm1_name
+        domain    = var.domain_name
       }
 
       network_interface {
-        ipv4_address = "${var.aci_vm1_address}"
+        ipv4_address = var.aci_vm1_address
         ipv4_netmask = "22"
       }
 
-      ipv4_gateway    = "${var.gateway}"
-      dns_server_list = "${var.dns_list}"
-      dns_suffix_list = "${var.dns_search}"
+      ipv4_gateway    = var.gateway
+      dns_server_list = var.dns_list
+      dns_suffix_list = var.dns_search
     }
   }
 }
 
 resource "vsphere_virtual_machine" "aci_vm2" {
   count = 1
-  name  = "${var.aci_vm2_name}"
+  name  = var.aci_vm2_name
 
-  #   resource_pool_id = "${data.vsphere_compute_cluster.cl.resource_pool_id}"
-  resource_pool_id = "${data.vsphere_host.host.resource_pool_id}"
-  datastore_id     = "${data.vsphere_datastore.ds.id}"
+  #   resource_pool_id = data.vsphere_compute_cluster.cl.resource_pool_id
+  resource_pool_id = data.vsphere_host.host.resource_pool_id
+  datastore_id     = data.vsphere_datastore.ds.id
 
   num_cpus = 2
   memory   = 4096
-  guest_id = "${data.vsphere_virtual_machine.template.guest_id}"
+  guest_id = data.vsphere_virtual_machine.template.guest_id
 
-  scsi_type = "${data.vsphere_virtual_machine.template.scsi_type}"
+  scsi_type = data.vsphere_virtual_machine.template.scsi_type
 
   disk {
     label = "disk0"
-    size  = "${data.vsphere_virtual_machine.template.disks.0.size}"
+    size  = data.vsphere_virtual_machine.template.disks.0.size
   }
 
   disk {
@@ -112,31 +112,31 @@ resource "vsphere_virtual_machine" "aci_vm2" {
     size        = 40
   }
 
-  folder = "${var.folder}"
+  folder = var.folder
 
   network_interface {
-    network_id   = "${data.vsphere_network.vm2_net.id}"
-    adapter_type = "${data.vsphere_virtual_machine.template.network_interface_types[0]}"
+    network_id   = data.vsphere_network.vm2_net.id
+    adapter_type = data.vsphere_virtual_machine.template.network_interface_types[0]
   }
 
   clone {
-    template_uuid = "${data.vsphere_virtual_machine.template.id}"
+    template_uuid = data.vsphere_virtual_machine.template.id
     linked_clone  = true
 
     customize {
       linux_options {
-        host_name = "${var.aci_vm2_name}"
-        domain    = "${var.domain_name}"
+        host_name = var.aci_vm2_name
+        domain    = var.domain_name
       }
 
       network_interface {
-        ipv4_address = "${var.aci_vm2_address}"
+        ipv4_address = var.aci_vm2_address
         ipv4_netmask = "22"
       }
 
-      ipv4_gateway    = "${var.gateway}"
-      dns_server_list = "${var.dns_list}"
-      dns_suffix_list = "${var.dns_search}"
+      ipv4_gateway    = var.gateway
+      dns_server_list = var.dns_list
+      dns_suffix_list = var.dns_search
     }
   }
 }

--- a/examples/aci_vmm/aci_resources/main.tf
+++ b/examples/aci_vmm/aci_resources/main.tf
@@ -10,71 +10,71 @@ resource "aci_tenant" "terraform_ten" {
 }
 
 resource "aci_vrf" "vrf1" {
-  tenant_dn = "${aci_tenant.terraform_ten.id}"
+  tenant_dn = aci_tenant.terraform_ten.id
   name      = "vrf1"
 }
 
 resource "aci_bridge_domain" "bd1" {
-  tenant_dn          = "${aci_tenant.terraform_ten.id}"
-  relation_fv_rs_ctx = "${aci_vrf.vrf1.name}"
+  tenant_dn          = aci_tenant.terraform_ten.id
+  relation_fv_rs_ctx = aci_vrf.vrf1.name
   name               = "bd1"
 }
 
 resource "aci_subnet" "bd1_subnet" {
-  bridge_domain_dn = "${aci_bridge_domain.bd1.id}"
+  bridge_domain_dn = aci_bridge_domain.bd1.id
   name             = "Subnet"
-  ip               = "${var.bd_subnet}"
+  ip               = var.bd_subnet
 }
 
 resource "aci_application_profile" "app1" {
-  tenant_dn = "${aci_tenant.terraform_ten.id}"
+  tenant_dn = aci_tenant.terraform_ten.id
   name      = "app1"
 }
 
 resource "aci_vmm_domain" "vds" {
-  provider_profile_dn = "${var.provider_profile_dn}"
-  name                = "${var.vmm_domain}"
+  provider_profile_dn = var.provider_profile_dn
+  name                = var.vmm_domain
 }
 
 resource "aci_application_epg" "epg1" {
-  application_profile_dn = "${aci_application_profile.app1.id}"
+  application_profile_dn = aci_application_profile.app1.id
   name                   = "epg1"
-  relation_fv_rs_bd      = "${aci_bridge_domain.bd1.name}"
-  relation_fv_rs_dom_att = ["${aci_vmm_domain.vds.id}"]
-  relation_fv_rs_cons    = ["${aci_contract.contract_epg1_epg2.name}"]
+  relation_fv_rs_bd      = aci_bridge_domain.bd1.name
+  relation_fv_rs_dom_att = [aci_vmm_domain.vds.id]
+  relation_fv_rs_cons    = [aci_contract.contract_epg1_epg2.name]
 }
 
 resource "aci_application_epg" "epg2" {
-  application_profile_dn = "${aci_application_profile.app1.id}"
+  application_profile_dn = aci_application_profile.app1.id
   name                   = "epg2"
-  relation_fv_rs_bd      = "${aci_bridge_domain.bd1.name}"
-  relation_fv_rs_dom_att = ["${aci_vmm_domain.vds.id}"]
-  relation_fv_rs_prov    = ["${aci_contract.contract_epg1_epg2.name}"]
+  relation_fv_rs_bd      = aci_bridge_domain.bd1.name
+  relation_fv_rs_dom_att = [aci_vmm_domain.vds.id]
+  relation_fv_rs_prov    = [aci_contract.contract_epg1_epg2.name]
 }
 
 resource "aci_contract" "contract_epg1_epg2" {
-  tenant_dn = "${aci_tenant.terraform_ten.id}"
+  tenant_dn = aci_tenant.terraform_ten.id
   name      = "Web"
 }
 
 resource "aci_contract_subject" "Web_subject1" {
-  contract_dn                  = "${aci_contract.contract_epg1_epg2.id}"
+  contract_dn                  = aci_contract.contract_epg1_epg2.id
   name                         = "Subject"
-  relation_vz_rs_subj_filt_att = ["${aci_filter.allow_https.name}","${aci_filter.allow_icmp.name}"]
+  relation_vz_rs_subj_filt_att = [aci_filter.allow_https.name,aci_filter.allow_icmp.name]
 }
 
 resource "aci_filter" "allow_https" {
-  tenant_dn = "${aci_tenant.terraform_ten.id}"
+  tenant_dn = aci_tenant.terraform_ten.id
   name      = "allow_https"
 }
 resource "aci_filter" "allow_icmp" {
-  tenant_dn = "${aci_tenant.terraform_ten.id}"
+  tenant_dn = aci_tenant.terraform_ten.id
   name      = "allow_icmp"
 }
 
 resource "aci_filter_entry" "https" {
   name        = "https"
-  filter_dn   = "${aci_filter.allow_https.id}"
+  filter_dn   = aci_filter.allow_https.id
   ether_t     = "ip"
   prot        = "tcp"
   d_from_port = "https"
@@ -84,7 +84,7 @@ resource "aci_filter_entry" "https" {
 
 resource "aci_filter_entry" "icmp" {
   name        = "icmp"
-  filter_dn   = "${aci_filter.allow_icmp.id}"
+  filter_dn   = aci_filter.allow_icmp.id
   ether_t     = "ip"
   prot        = "icmp"
   stateful    = "yes"

--- a/examples/aci_vmm/aci_resources/outputs.tf
+++ b/examples/aci_vmm/aci_resources/outputs.tf
@@ -1,13 +1,13 @@
 output "aci_tenant_name" {
-  value = "${aci_tenant.terraform_ten.name}"
+  value = aci_tenant.terraform_ten.name
 }
 
 output "aci_epg_name" {
-  value = "${aci_application_epg.epg1.name}"
+  value = aci_application_epg.epg1.name
 }
 
 output "aci_application_profile_name" {
-  value = "${aci_application_profile.app1.name}"
+  value = aci_application_profile.app1.name
 }
 
 

--- a/examples/aci_vmm/main.tf
+++ b/examples/aci_vmm/main.tf
@@ -6,9 +6,9 @@ module "aci" {
 module "vcenter" {
   source = "./vmware_resources"
 
-  aci_tenant_name = "${module.aci.aci_tenant_name}"
-  aci_application_profile_name = "${module.aci.aci_application_profile_name}"
-  aci_epg_name = "${module.aci.aci_epg_name}"
+  aci_tenant_name = module.aci.aci_tenant_name
+  aci_application_profile_name = module.aci.aci_application_profile_name
+  aci_epg_name = module.aci.aci_epg_name
   
 }
 

--- a/examples/aci_vmm/vmware_resources/main.tf
+++ b/examples/aci_vmm/vmware_resources/main.tf
@@ -1,109 +1,109 @@
 provider "vsphere" {
-  user                 = "${var.vsphere_user}"
-  password             = "${var.vsphere_password}"
-  vsphere_server       = "${var.vsphere_server}"
+  user                 = var.vsphere_user
+  password             = var.vsphere_password
+  vsphere_server       = var.vsphere_server
   allow_unverified_ssl = true
 }
 
 data "vsphere_datacenter" "dc" {
-  name = "${var.vsphere_datacenter}"
+  name = var.vsphere_datacenter
 }
 
 data "vsphere_network" "vm1_net" {
-  name          = "${format("%v|%v|%v", var.aci_tenant_name, var.aci_application_profile_name, var.aci_epg_name)}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = format("%v|%v|%v", var.aci_tenant_name, var.aci_application_profile_name, var.aci_epg_name)
+  datacenter_id = data.vsphere_datacenter.dc.id
 }
 
 data "vsphere_network" "vm2_net" {
-  name          = "${format("%v|%v|%v", var.aci_tenant_name, var.aci_application_profile_name, var.aci_epg_name)}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = format("%v|%v|%v", var.aci_tenant_name, var.aci_application_profile_name, var.aci_epg_name)
+  datacenter_id = data.vsphere_datacenter.dc.id
 }
 
 data "vsphere_datastore" "ds" {
-  name          = "${var.vsphere_datastore}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = var.vsphere_datastore
+  datacenter_id = data.vsphere_datacenter.dc.id
 }
 
 # data "vsphere_compute_cluster" "cl" {
-#   name          = "${var.vsphere_compute_cluster}"
-#   datacenter_id = "${data.vsphere_datacenter.dc.id}"
+#   name          = var.vsphere_compute_cluster
+#   datacenter_id = data.vsphere_datacenter.dc.id
 # }
 
 data "vsphere_host" "host" {
-  name          = "${var.vsphere_host_name}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = var.vsphere_host_name
+  datacenter_id = data.vsphere_datacenter.dc.id
 }
 
 data "vsphere_virtual_machine" "template" {
-  name          = "${var.vsphere_template}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = var.vsphere_template
+  datacenter_id = data.vsphere_datacenter.dc.id
 }
 
 resource "vsphere_virtual_machine" "aci_vm1" {
   count        = 1
-  name         = "${var.aci_vm1_name}"
-  datastore_id = "${data.vsphere_datastore.ds.id}"
+  name         = var.aci_vm1_name
+  datastore_id = data.vsphere_datastore.ds.id
 
   num_cpus = 8
   memory   = 24576
-  guest_id = "${data.vsphere_virtual_machine.template.guest_id}"
+  guest_id = data.vsphere_virtual_machine.template.guest_id
 
-  #   resource_pool_id = "${data.vsphere_compute_cluster.cl.resource_pool_id}"
+  #   resource_pool_id = data.vsphere_compute_cluster.cl.resource_pool_id
 
-  resource_pool_id = "${data.vsphere_host.host.resource_pool_id}"
-  scsi_type = "${data.vsphere_virtual_machine.template.scsi_type}"
+  resource_pool_id = data.vsphere_host.host.resource_pool_id
+  scsi_type = data.vsphere_virtual_machine.template.scsi_type
   disk {
     label = "disk0"
-    size  = "${data.vsphere_virtual_machine.template.disks.0.size}"
+    size  = data.vsphere_virtual_machine.template.disks.0.size
   }
   disk {
     unit_number = 1
     label       = "disk1"
     size        = 40
   }
-  folder = "${var.folder}"
+  folder = var.folder
   network_interface {
-    network_id   = "${data.vsphere_network.vm1_net.id}"
-    adapter_type = "${data.vsphere_virtual_machine.template.network_interface_types[0]}"
+    network_id   = data.vsphere_network.vm1_net.id
+    adapter_type = data.vsphere_virtual_machine.template.network_interface_types[0]
   }
   clone {
-    template_uuid = "${data.vsphere_virtual_machine.template.id}"
+    template_uuid = data.vsphere_virtual_machine.template.id
 
     customize {
       linux_options {
-        host_name = "${var.aci_vm1_name}"
-        domain    = "${var.domain_name}"
+        host_name = var.aci_vm1_name
+        domain    = var.domain_name
       }
 
       network_interface {
-        ipv4_address = "${var.aci_vm1_address}"
+        ipv4_address = var.aci_vm1_address
         ipv4_netmask = "22"
       }
 
-      ipv4_gateway    = "${var.gateway}"
-      dns_server_list = "${var.dns_list}"
-      dns_suffix_list = "${var.dns_search}"
+      ipv4_gateway    = var.gateway
+      dns_server_list = var.dns_list
+      dns_suffix_list = var.dns_search
     }
   }
 }
 
 resource "vsphere_virtual_machine" "aci_vm2" {
   count = 1
-  name  = "${var.aci_vm2_name}"
+  name  = var.aci_vm2_name
 
-  #   resource_pool_id = "${data.vsphere_compute_cluster.cl.resource_pool_id}"
-  resource_pool_id = "${data.vsphere_host.host.resource_pool_id}"
-  datastore_id     = "${data.vsphere_datastore.ds.id}"
+  #   resource_pool_id = data.vsphere_compute_cluster.cl.resource_pool_id
+  resource_pool_id = data.vsphere_host.host.resource_pool_id
+  datastore_id     = data.vsphere_datastore.ds.id
 
   num_cpus = 8
   memory   = 24576
-  guest_id = "${data.vsphere_virtual_machine.template.guest_id}"
+  guest_id = data.vsphere_virtual_machine.template.guest_id
 
-  scsi_type = "${data.vsphere_virtual_machine.template.scsi_type}"
+  scsi_type = data.vsphere_virtual_machine.template.scsi_type
 
   disk {
     label = "disk0"
-    size  = "${data.vsphere_virtual_machine.template.disks.0.size}"
+    size  = data.vsphere_virtual_machine.template.disks.0.size
   }
 
   disk {
@@ -112,30 +112,30 @@ resource "vsphere_virtual_machine" "aci_vm2" {
     size        = 40
   }
 
-  folder = "${var.folder}"
+  folder = var.folder
 
   network_interface {
-    network_id   = "${data.vsphere_network.vm2_net.id}"
-    adapter_type = "${data.vsphere_virtual_machine.template.network_interface_types[0]}"
+    network_id   = data.vsphere_network.vm2_net.id
+    adapter_type = data.vsphere_virtual_machine.template.network_interface_types[0]
   }
 
   clone {
-    template_uuid = "${data.vsphere_virtual_machine.template.id}"
+    template_uuid = data.vsphere_virtual_machine.template.id
 
     customize {
       linux_options {
-        host_name = "${var.aci_vm2_name}"
-        domain    = "${var.domain_name}"
+        host_name = var.aci_vm2_name
+        domain    = var.domain_name
       }
 
       network_interface {
-        ipv4_address = "${var.aci_vm2_address}"
+        ipv4_address = var.aci_vm2_address
         ipv4_netmask = "22"
       }
 
-      ipv4_gateway    = "${var.gateway}"
-      dns_server_list = "${var.dns_list}"
-      dns_suffix_list = "${var.dns_search}"
+      ipv4_gateway    = var.gateway
+      dns_server_list = var.dns_list
+      dns_suffix_list = var.dns_search
     }
   }
 }

--- a/examples/all/main.tf
+++ b/examples/all/main.tf
@@ -12,26 +12,26 @@ resource "aci_tenant" "madebytf2" {
 }
 
 resource "aci_app_profile" "madebytf2" {
-  tenant_dn   = "${aci_tenant.madebytf2.id}"
+  tenant_dn   = aci_tenant.madebytf2.id
   name        = "madebytf2"
   description = "This app profile is created by terraform"
 }
 
 resource "aci_epg" "madebytf2" {
-  application_profile_dn = "${aci_app_profile.madebytf2.id}"
+  application_profile_dn = aci_app_profile.madebytf2.id
   name                   = "madebytf2"
   description            = "This epg is created by terraform"
 }
 
 resource "aci_bridge_domain" "madebytf2" {
-  tenant_dn   = "${aci_tenant.madebytf2.id}"
+  tenant_dn   = aci_tenant.madebytf2.id
   name        = "madebytf2"
   description = "This bridge domain is created by terraform"
   mac         = "00:22:BD:F8:19:FF"
 }
 
 resource "aci_contract" "madebytf2" {
-  tenant_dn   = "${aci_tenant.madebytf2.id}"
+  tenant_dn   = aci_tenant.madebytf2.id
   name        = "madebytfsdfsdf"
   description = "This contract is created by terraform"
   scope       = "context"
@@ -39,27 +39,27 @@ resource "aci_contract" "madebytf2" {
 }
 
 resource "aci_subject" "madebytf2" {
-  contract_dn = "${aci_contract.madebytf2.id}"
+  contract_dn = aci_contract.madebytf2.id
   name        = "madebytftt"
   description = "This subject is created by terraform"
 }
 
 resource "aci_subnet" "madebytf2" {
   name             = "10.0.3.28/27"
-  bridge_domain_dn = "${aci_bridge_domain.madebytf2.id}"
+  bridge_domain_dn = aci_bridge_domain.madebytf2.id
   ip_address       = "10.0.3.28/27"
   scope            = ["private"]
   description      = "This subject is created by terraform"
 }
 
 resource "aci_filter" "madebytf2" {
-  tenant_dn   = "${aci_tenant.madebytf2.id}"
+  tenant_dn   = aci_tenant.madebytf2.id
   name        = "madebytf"
   description = "This filter is created by terraform"
 }
 
 resource "aci_entry" "madebytf2" {
-  filter_dn   = "${aci_filter.madebytf2.id}"
+  filter_dn   = aci_filter.madebytf2.id
   name        = "madebytf"
   description = "This entry is created by terraform"
 }

--- a/examples/ansible_parity_modules/main.tf
+++ b/examples/ansible_parity_modules/main.tf
@@ -26,12 +26,12 @@ resource "aci_tenant" "test_tenant1" {
 }
 
 resource "aci_monitoring_policy" "foomonitoring_policy" {
-  tenant_dn = "${aci_tenant.test_tenant1.id}"
+  tenant_dn = aci_tenant.test_tenant1.id
   name = "monepgpol1"
 }
 
 resource "aci_action_rule_profile" "fooaction_rule_profile" {
-  tenant_dn = "${aci_tenant.test_tenant1.id}"
+  tenant_dn = aci_tenant.test_tenant1.id
   name = "rtctrlAttrP1"
 }
 
@@ -44,7 +44,7 @@ resource "aci_physical_domain" "foophysical_domain" {
 }
 
 resource "aci_taboo_contract" "footaboo_contract" {
-  tenant_dn = "${aci_tenant.test_tenant1.id}"
+  tenant_dn = aci_tenant.test_tenant1.id
   name = "vztaboo1"
 }
 
@@ -53,23 +53,23 @@ resource "aci_leaf_profile" "tf_leaf_prof" {
 }
 
 resource "aci_switch_association" "fooswitch_association" {
-  leaf_profile_dn = "${aci_leaf_profile.tf_leaf_prof.id}"
+  leaf_profile_dn = aci_leaf_profile.tf_leaf_prof.id
   name = "infraLeafs1"
   switch_association_type = "ALL"
 }
 
 resource "aci_span_destination_group" "foospan_destination_group" {
-  tenant_dn = "${aci_tenant.test_tenant1.id}"
+  tenant_dn = aci_tenant.test_tenant1.id
   name = "spanDestGrp1"
 }
 
 resource "aci_span_source_group" "foospan_source_group" {
-  tenant_dn = "${aci_tenant.test_tenant1.id}"
+  tenant_dn = aci_tenant.test_tenant1.id
   name = "spanSrcGrp1"
 }
 
 resource "aci_span_sourcedestination_group_match_label" "foospan_sourcedestination_group_match_label" {
-  span_source_group_dn = "${aci_span_source_group.foospan_source_group.id}"
+  span_source_group_dn = aci_span_source_group.foospan_source_group.id
   name = "spanLbl1"
 }
 
@@ -79,7 +79,7 @@ resource "aci_vlan_pool" "foovlan_pool" {
 }
 
 resource "fcDomP" "fooranges" {
-  vlan_pool_dn = "${aci_vlan_pool.foovlan_pool.id}"
+  vlan_pool_dn = aci_vlan_pool.foovlan_pool.id
   _from        = "vlan-25"
   to           = "vlan-35"
   alloc_mode   = "inherit"
@@ -133,13 +133,13 @@ resource "aci_leaf_interface_profile" "test_leaf_profile" {
 }
 
 resource "aci_access_port_selector" "test_selector" {
-    leaf_interface_profile_dn = "${aci_leaf_interface_profile.test_leaf_profile.id}"
+    leaf_interface_profile_dn = aci_leaf_interface_profile.test_leaf_profile.id
     name = "tf_test"
     access_port_selector_type = "default"
 }
 
 resource "aci_access_sub_port_block" "fooaccess_sub_port_block" {
-  access_port_selector_dn = "${aci_access_port_selector.test_selector.id}"
+  access_port_selector_dn = aci_access_port_selector.test_selector.id
   name = "infraSubportBlk1"
 }
 
@@ -151,12 +151,12 @@ resource "aci_vpc_explicit_protection_group" "foovpc_explicit_protection_group" 
 }
 
 resource "aci_node_block_maintgrp" "foonode_block_maintgrp" {
-  pod_maintenance_group_dn = "${aci_pod_maintenance_group.foopod_maintenance_group.id}"
+  pod_maintenance_group_dn = aci_pod_maintenance_group.foopod_maintenance_group.id
   name = "fabricNodeBlkMG"
 }
 
 resource "aci_node_block_firmware" "foonode_block_firmware" {
- firmware_group_dn = "${aci_firmware_group.foofirmware_group.id}"
+ firmware_group_dn = aci_firmware_group.foofirmware_group.id
  name = "fabricNodeBlkFW" 
 }
 

--- a/examples/app_profile/app_profile.tf
+++ b/examples/app_profile/app_profile.tf
@@ -4,10 +4,10 @@ resource "aci_tenant" "tenant_for_ap" {
 }
 
 resource "aci_application_profile" "demo_app_profile" {
-  tenant_dn                 = "${aci_tenant.tenant_for_ap.id}"
+  tenant_dn                 = aci_tenant.tenant_for_ap.id
   name                      = "test_tf_ap"
   description               = "This app profile is created by terraform ACI provider"
   prio                      = "unspecified"
   annotation                = "test_ap_anot"
-  relation_fv_rs_ap_mon_pol = "${aci_rest.rest_mon_epg_pol.id}"                       # Relation to class monEPGPol. Cardinality - N_TO_ONE
+  relation_fv_rs_ap_mon_pol = aci_rest.rest_mon_epg_pol.id                     # Relation to class monEPGPol. Cardinality - N_TO_ONE
 }

--- a/examples/bridge_domain/bd.tf
+++ b/examples/bridge_domain/bd.tf
@@ -4,7 +4,7 @@ resource "aci_tenant" "tenant_for_bridge_domain" {
 }
 
 resource "aci_bridge_domain" "demobd" {
-  tenant_dn                      = "${aci_tenant.tenant_for_bridge_domain.id}"
+  tenant_dn                      = aci_tenant.tenant_for_bridge_domain.id
   name                           = "test_tf_bd"
   description                    = "This bridge domain is created by terraform ACI provider"
   mac                            = "00:22:BD:F8:19:FF"
@@ -23,16 +23,16 @@ resource "aci_bridge_domain" "demobd" {
   unk_mac_ucast_act              = "flood"
   unk_mcast_act                  = "flood"
   vmac                           = "not-applicable"
-  relation_fv_rs_bd_to_profile   = "${aci_rest.rest_rt_ctrl_profile.id}" # Relation to rtctrlProfile class. Cardinality - N_TO_ONE
-  relation_fv_rs_bd_to_relay_p   = "${aci_rest.rest_dhcp_RelayP.id}"     # Relation to dhcpRelayP class. Cardinality - N_TO_ONE
-  relation_fv_rs_abd_pol_mon_pol = "${aci_rest.rest_mon_epg_pol.id}"     # Relation to monEPGPol class. Cardinality - N_TO_ONE
-  relation_fv_rs_bd_flood_to     = ["${aci_filter.bd_flood_filter.id}"]  # Relation to vzFilter class. Cardinality - N_TO_M
-  relation_fv_rs_bd_to_fhs       = "${aci_rest.rest_fhs_bd_pol.id}"      # Relation to fhsBDPol class. Cardinality - N_TO_ONE.
+  relation_fv_rs_bd_to_profile   = aci_rest.rest_rt_ctrl_profile.id # Relation to rtctrlProfile class. Cardinality - N_TO_ONE
+  relation_fv_rs_bd_to_relay_p   = aci_rest.rest_dhcp_RelayP.id     # Relation to dhcpRelayP class. Cardinality - N_TO_ONE
+  relation_fv_rs_abd_pol_mon_pol = aci_rest.rest_mon_epg_pol.id     # Relation to monEPGPol class. Cardinality - N_TO_ONE
+  relation_fv_rs_bd_flood_to     = [aci_filter.bd_flood_filter.id]  # Relation to vzFilter class. Cardinality - N_TO_M
+  relation_fv_rs_bd_to_fhs       = aci_rest.rest_fhs_bd_pol.id     # Relation to fhsBDPol class. Cardinality - N_TO_ONE.
 
   relation_fv_rs_bd_to_netflow_monitor_pol {
-    tn_netflow_monitor_pol_name = "${aci_rest.rest_net_flow_pol.id}"
+    tn_netflow_monitor_pol_name = aci_rest.rest_net_flow_pol.id
     flt_type                    = "ipv4"
   } # Relation to netflowMonitorPol class. Cardinality - N_TO_M
 
-  relation_fv_rs_bd_to_out = ["${aci_rest.rest_l3_ext_out.id}"] # Relation to l3extOut class. Cardinality - N_TO_M 
+  relation_fv_rs_bd_to_out = [aci_rest.rest_l3_ext_out.id] # Relation to l3extOut class. Cardinality - N_TO_M
 }

--- a/examples/bridge_domain/filter.tf
+++ b/examples/bridge_domain/filter.tf
@@ -4,7 +4,7 @@ resource "aci_tenant" "tenant_for_filter" {
 }
 
 resource "aci_filter" "bd_flood_filter" {
-  tenant_dn   = "${aci_tenant.tenant_for_filter.id}"
+  tenant_dn   = aci_tenant.tenant_for_filter.id
   name        = "test_tf_filter"
   description = "This filter is created by terraform ACI provider."
 }

--- a/examples/cloud_apic/aws.tf
+++ b/examples/cloud_apic/aws.tf
@@ -29,13 +29,13 @@ data "aws_subnet" "capic_subnet" {
   }
 
   availability_zone = "us-west-1a"
-  vpc_id            = "${data.aws_vpc.capic_vpc.id}"
+  vpc_id            = data.aws_vpc.capic_vpc.id
 }
 
 resource "aws_instance" "web" {
-  ami                         = "${data.aws_ami.ubuntu.id}"
+  ami                         = data.aws_ami.ubuntu.id
   instance_type               = "t2.micro"
-  subnet_id                   = "${data.aws_subnet.capic_subnet.id}"
+  subnet_id                   = data.aws_subnet.capic_subnet.id
   associate_public_ip_address = true
 
   tags = {

--- a/examples/cloud_apic/main.tf
+++ b/examples/cloud_apic/main.tf
@@ -3,13 +3,13 @@ resource "aci_tenant" "terraform_ten" {
 }
 
 resource "aci_vrf" "vrf1" {
-  tenant_dn = "${aci_tenant.terraform_ten.id}"
+  tenant_dn = aci_tenant.terraform_ten.id
   name      = "devnet--vrftf"
 }
 
 resource "aci_cloud_aws_provider" "cloud_apic_provider" {
   name              = "aws"
-  tenant_dn         = "${aci_tenant.terraform_ten.id}"
+  tenant_dn         = aci_tenant.terraform_ten.id
   access_key_id     = ""
   secret_access_key = ""
   account_id        = ""
@@ -21,54 +21,54 @@ data "aci_cloud_domain_profile" "cloud_domp" {
 }
 
 resource "aci_cloud_applicationcontainer" "app1" {
-  tenant_dn = "${aci_tenant.terraform_ten.id}"
+  tenant_dn = aci_tenant.terraform_ten.id
   name      = "app1"
 }
 
 resource "aci_bridge_domain" "bd1" {
-  tenant_dn          = "${aci_tenant.terraform_ten.id}"
-  relation_fv_rs_ctx = "${aci_vrf.vrf1.name}"
+  tenant_dn          = aci_tenant.terraform_ten.id
+  relation_fv_rs_ctx = aci_vrf.vrf1.name
   name               = "bd1"
 }
 
 resource "aci_cloud_epg" "cloud_apic_epg" {
   name                             = "epg1"
-  cloud_applicationcontainer_dn    = "${aci_cloud_applicationcontainer.app1.id}"
-  relation_fv_rs_prov              = ["${aci_contract.contract_epg1_epg2.name}"]
-  relation_fv_rs_cons              = ["${aci_contract.contract_epg1_epg2.name}"]
-  relation_cloud_rs_cloud_epg_ctx = "${aci_vrf.vrf1.name}"
+  cloud_applicationcontainer_dn    = aci_cloud_applicationcontainer.app1.id
+  relation_fv_rs_prov              = [aci_contract.contract_epg1_epg2.name]
+  relation_fv_rs_cons              = [aci_contract.contract_epg1_epg2.name]
+  relation_cloud_rs_cloud_epg_ctx = aci_vrf.vrf1.name
 }
 
 resource "aci_cloud_endpoint_selector" "cloud_ep_selector" {
-  cloud_epg_dn    = "${aci_cloud_epg.cloud_apic_epg.id}"
+  cloud_epg_dn    = aci_cloud_epg.cloud_apic_epg.id
   name             = "devnet-ep-select"
   match_expression = "custom:Name=='-ep2'"
 }
 
 resource "aci_contract" "contract_epg1_epg2" {
-  tenant_dn = "${aci_tenant.terraform_ten.id}"
+  tenant_dn = aci_tenant.terraform_ten.id
   name      = "Web"
 }
 
 resource "aci_contract_subject" "Web_subject1" {
-  contract_dn                  = "${aci_contract.contract_epg1_epg2.id}"
+  contract_dn                  = aci_contract.contract_epg1_epg2.id
   name                         = "Subject"
-  relation_vz_rs_subj_filt_att = ["${aci_filter.allow_https.name}", "${aci_filter.allow_icmp.name}"]
+  relation_vz_rs_subj_filt_att = [aci_filter.allow_https.name, aci_filter.allow_icmp.name]
 }
 
 resource "aci_filter" "allow_https" {
-  tenant_dn = "${aci_tenant.terraform_ten.id}"
+  tenant_dn = aci_tenant.terraform_ten.id
   name      = "allow_https"
 }
 
 resource "aci_filter" "allow_icmp" {
-  tenant_dn = "${aci_tenant.terraform_ten.id}"
+  tenant_dn = aci_tenant.terraform_ten.id
   name      = "allow_icmp"
 }
 
 resource "aci_filter_entry" "https" {
   name        = "https"
-  filter_dn   = "${aci_filter.allow_https.id}"
+  filter_dn   = aci_filter.allow_https.id
   ether_t     = "ip"
   prot        = "tcp"
   d_from_port = "https"
@@ -78,22 +78,22 @@ resource "aci_filter_entry" "https" {
 
 resource "aci_filter_entry" "icmp" {
   name      = "icmp"
-  filter_dn = "${aci_filter.allow_icmp.id}"
+  filter_dn = aci_filter.allow_icmp.id
   ether_t   = "ip"
   prot      = "icmp"
   stateful  = "yes"
 }
 
 resource "aci_cloud_external_epg" "cloud_epic_ext_epg" {
-  cloud_applicationcontainer_dn    = "${aci_cloud_applicationcontainer.app1.id}"
+  cloud_applicationcontainer_dn    = aci_cloud_applicationcontainer.app1.id
   name                             = "devnet--inet"
-  relation_fv_rs_prov              = ["${aci_contract.contract_epg1_epg2.name}"]
-  relation_fv_rs_cons              = ["${aci_contract.contract_epg1_epg2.name}"]
-  relation_cloud_rs_cloud_epg_ctx = "${aci_vrf.vrf1.name}"
+  relation_fv_rs_prov              = [aci_contract.contract_epg1_epg2.name]
+  relation_fv_rs_cons              = [aci_contract.contract_epg1_epg2.name]
+  relation_cloud_rs_cloud_epg_ctx = aci_vrf.vrf1.name
 }
 
 resource "aci_cloud_endpoint_selectorfor_external_epgs" "ext_ep_selector" {
-  cloud_external_epg_dn = "${aci_cloud_external_epg.cloud_epic_ext_epg.id}"
+  cloud_external_epg_dn = aci_cloud_external_epg.cloud_epic_ext_epg.id
   name                   = "devnet-ext"
   subnet                 = "0.0.0.0/0"
 }
@@ -101,21 +101,21 @@ resource "aci_cloud_endpoint_selectorfor_external_epgs" "ext_ep_selector" {
 resource "aci_cloud_context_profile" "context_profile" {
   name                     = "devnet--cloud-ctx-profile"
   description              = "context provider created with terraform"
-  tenant_dn                = "${aci_tenant.terraform_ten.id}"
+  tenant_dn                = aci_tenant.terraform_ten.id
   primary_cidr             = "10.230.231.1/16"
   region                   = "us-west-1"
-  relation_cloud_rs_to_ctx = "${aci_vrf.vrf1.id}"
+  relation_cloud_rs_to_ctx = aci_vrf.vrf1.id
   depends_on               = ["aci_filter_entry.icmp"]
 }
 
 data "aci_cloud_cidr_pool" "prim_cidr" {
-  cloud_context_profile_dn = "${aci_cloud_context_profile.context_profile.id}"
+  cloud_context_profile_dn = aci_cloud_context_profile.context_profile.id
   addr                     = "10.230.231.1/16"
   name                     = "10.230.231.1/16"
 }
 
 resource "aci_cloud_subnet" "cloud_apic_subnet" {
-  cloud_cidr_pool_dn            = "${data.aci_cloud_cidr_pool.prim_cidr.id}"
+  cloud_cidr_pool_dn            = data.aci_cloud_cidr_pool.prim_cidr.id
   name                          = "10.230.231.1/24"
   ip                            = "10.230.231.1/24"
   relation_cloud_rs_zone_attach = "uni/clouddomp/provp-aws/region-us-west-1/zone-us-west-1a"

--- a/examples/cloud_ctx_profile/main.tf
+++ b/examples/cloud_ctx_profile/main.tf
@@ -15,10 +15,10 @@ resource "aci_tenant" "tenentcheck" {
 resource "aci_cloud_context_profile" "ctx1" {
   name                     = "check"
   description              = "cloud_context_profile created while acceptance testing"
-  tenant_dn                = "${aci_tenant.tenentcheck.id}"
+  tenant_dn                = aci_tenant.tenentcheck.id
   primary_cidr             = "10.0.0.0/16"
   region                   = "us-west-1"
   cloud_vendor             = "aws"
-  relation_cloud_rs_to_ctx = "${aci_vrf.vrf1.id}"
+  relation_cloud_rs_to_ctx = aci_vrf.vrf1.id
   hub_network              = "uni/tn-infra/gwrouterp-default"
 }

--- a/examples/cloud_lb_simplehttp/main.tf
+++ b/examples/cloud_lb_simplehttp/main.tf
@@ -96,7 +96,7 @@ resource "aci_rest" "appliedServiceGraph" {
           children:
           - vnsAbsGraph:
               attributes:
-                name: ${var.name}
+                name: var.name
               children:
               - vnsAbsNode:
                   attributes:
@@ -111,7 +111,7 @@ resource "aci_rest" "appliedServiceGraph" {
                       - cloudListener:
                           attributes:
                             name: http_listener
-                            port: "${var.listenerPort}"
+                            port: var.listenerPort
                             protocol: http
                           children:
                           - cloudListenerRule:
@@ -122,8 +122,8 @@ resource "aci_rest" "appliedServiceGraph" {
                               children:
                               - cloudRuleAction:
                                   attributes:
-                                    epgdn: ${var.epg_dn}
-                                    port: "${var.hostPort}"
+                                    epgdn: var.epg_dn
+                                    port: var.hostPort
                                     protocol: http
                                     type: forward
           - vzBrCP:
@@ -136,7 +136,7 @@ resource "aci_rest" "appliedServiceGraph" {
                  children:
                  - vzRsSubjGraphAtt:
                      attributes:
-                       tnVnsAbsGraphName: ${var.name}
+                       tnVnsAbsGraphName: var.name
   EOF
 }
 

--- a/examples/cloud_subnet/main.tf
+++ b/examples/cloud_subnet/main.tf
@@ -13,28 +13,28 @@ resource "aci_tenant" "tenentcheck" {
 }
 
 resource "aci_vrf" "vrf1" {
-  tenant_dn = "${aci_tenant.tenentcheck.id}"
+  tenant_dn = aci_tenant.tenentcheck.id
   name      = "vrf-1"
 }
 
 resource "aci_cloud_context_profile" "ctx1" {
   name                     = "check"
   description              = "cloud_context_profile created while acceptance testing"
-  tenant_dn                = "${aci_tenant.tenentcheck.id}"
+  tenant_dn                = aci_tenant.tenentcheck.id
   primary_cidr             = "10.0.0.0/16"
   region                   = "us-west-1"
   cloud_vendor             = "aws"
-  relation_cloud_rs_to_ctx = "${aci_vrf.vrf1.id}"
+  relation_cloud_rs_to_ctx = aci_vrf.vrf1.id
   hub_network              = "uni/tn-infra/gwrouterp-default"
 }
 
 resource "aci_cloud_cidr_pool" "cloud_cidr_pool" {
-  cloud_context_profile_dn = "${aci_cloud_context_profile.ctx1.id}"
+  cloud_context_profile_dn = aci_cloud_context_profile.ctx1.id
   addr                     = "10.0.0.0/16"
 }
 
 resource "aci_cloud_subnet" "cloud_subnet" {
-  cloud_cidr_pool_dn = "${aci_cloud_cidr_pool.cloud_cidr_pool.id}"
+  cloud_cidr_pool_dn = aci_cloud_cidr_pool.cloud_cidr_pool.id
   ip                 = "10.0.1.0/24"
   usage              = "gateway"
   zone               = "uni/clouddomp/provp-aws/region-us-west-1/zone-us-west-1b"

--- a/examples/contract/contract.tf
+++ b/examples/contract/contract.tf
@@ -4,11 +4,11 @@ resource "aci_tenant" "tenant_for_contract" {
 }
 
 resource "aci_contract" "democontract" {
-  tenant_dn                = "${aci_tenant.tenant_for_contract.id}"
+  tenant_dn                = aci_tenant.tenant_for_contract.id
   name                     = "test_tf_contract"
   description              = "This contract is created by terraform ACI provider"
   scope                    = "context"
   target_dscp              = "VA"
   prio                     = "unspecified"
-  relation_vz_rs_graph_att = "${aci_rest.rest_abs_graph.id}" # Relation to vnsAbsGraph class. Cardinality - N_TO_ONE
+  relation_vz_rs_graph_att = aci_rest.rest_abs_graph.id # Relation to vnsAbsGraph class. Cardinality - N_TO_ONE
 }

--- a/examples/data_sources/main.tf
+++ b/examples/data_sources/main.tf
@@ -10,48 +10,48 @@ data "aci_tenant" "tenant_fetch" {
 }
 
 data "aci_application_profile" "ap_fetch" {
-  tenant_dn = "${data.aci_tenant.tenant_fetch.id}"
+  tenant_dn = data.aci_tenant.tenant_fetch.id
   name      = "data_source_ap"
 }
 
 data "aci_application_epg" "epg_fetch" {
-  application_profile_dn = "${data.aci_application_profile.ap_fetch.id}"
+  application_profile_dn = data.aci_application_profile.ap_fetch.id
   name                   = "data_source_epg"
 }
 
 data "aci_vrf" "vrf_fetch" {
-  tenant_dn = "${data.aci_tenant.tenant_fetch.id}"
+  tenant_dn = data.aci_tenant.tenant_fetch.id
   name      = "data_source_vrf"
 }
 
 data "aci_bridge_domain" "bd_fetch" {
-  tenant_dn = "${data.aci_tenant.tenant_fetch.id}"
+  tenant_dn = data.aci_tenant.tenant_fetch.id
   name      = "data_source_bd"
 }
 
 data "aci_subnet" "subnet_fetch" {
-  bridge_domain_dn = "${data.aci_bridge_domain.bd_fetch.id}"
+  bridge_domain_dn = data.aci_bridge_domain.bd_fetch.id
   ip               = "10.0.1.1/24"
   name             = "10.0.1.1/24"
 }
 
 data "aci_contract" "contract_fecth" {
-  tenant_dn = "${data.aci_tenant.tenant_fetch.id}"
+  tenant_dn = data.aci_tenant.tenant_fetch.id
   name      = "data_source_contract"
 }
 
 data "aci_contract_subject" "subject_fetch" {
-  contract_dn = "${data.aci_contract.contract_fecth.id}"
+  contract_dn = data.aci_contract.contract_fecth.id
   name        = "data_source_subject"
 }
 
 data "aci_filter" "fiter_fetch" {
-  tenant_dn = "${data.aci_tenant.tenant_fetch.id}"
+  tenant_dn = data.aci_tenant.tenant_fetch.id
   name      = "data_source_filter"
 }
 
 data "aci_filter_entry" "fetch_entry" {
-  filter_dn = "${data.aci_filter.fiter_fetch.id}"
+  filter_dn = data.aci_filter.fiter_fetch.id
   name      = "data_source_entry"
 }
 

--- a/examples/data_sources/outputs.tf
+++ b/examples/data_sources/outputs.tf
@@ -1,42 +1,42 @@
 output "tenant_dn" {
-  value = "${data.aci_tenant.tenant_fetch.id}"
+  value = data.aci_tenant.tenant_fetch.id
 }
 
 output "app_dn" {
-  value = "${data.aci_application_profile.ap_fetch.id}"
+  value = data.aci_application_profile.ap_fetch.id
 }
 
 output "epg_dn" {
-  value = "${data.aci_application_epg.epg_fetch.id}"
+  value = data.aci_application_epg.epg_fetch.id
 }
 
 output "bridge_domain_dn" {
-  value = "${data.aci_bridge_domain.bd_fetch.id}"
+  value = data.aci_bridge_domain.bd_fetch.id
 }
 
 output "subnet_dn" {
-  value = "${data.aci_subnet.subnet_fetch.id}"
+  value = data.aci_subnet.subnet_fetch.id
 }
 output "contract_dn" {
-  value = "${data.aci_contract.contract_fecth.id}"
+  value = data.aci_contract.contract_fecth.id
 }
 
 output "subject_dn" {
-  value = "${data.aci_contract_subject.subject_fetch.id}"
+  value = data.aci_contract_subject.subject_fetch.id
 }
 
 output "filter_dn" {
-  value = "${data.aci_filter.fiter_fetch.id}"
+  value = data.aci_filter.fiter_fetch.id
 }
 output "entry_dn" {
-  value = "${data.aci_filter_entry.fetch_entry.id}"
+  value = data.aci_filter_entry.fetch_entry.id
 }
 
 output "vrf_dn" {
-  value = "${data.aci_vrf.vrf_fetch.id}"
+  value = data.aci_vrf.vrf_fetch.id
 }
 output "vm_domain_dn" {
-  value = "${data.aci_vmm_domain.fetch_domain.id}"
+  value = data.aci_vmm_domain.fetch_domain.id
 }
 
 

--- a/examples/demo_examples/app_profile.tf
+++ b/examples/demo_examples/app_profile.tf
@@ -1,5 +1,5 @@
 resource "aci_app_profile" "demo_app_profile" {
-  tenant_dn   = "${aci_tenant.demotenant.id}"
+  tenant_dn   = aci_tenant.demotenant.id
   name        = "test_tf_ap"
   description = "This app profile is created by terraform ACI provider"
 }

--- a/examples/demo_examples/bd.tf
+++ b/examples/demo_examples/bd.tf
@@ -4,7 +4,7 @@ resource "aci_tenant" "tenant_for_bridge_domain" {
 }
 
 resource "aci_bridge_domain" "demobd" {
-  tenant_dn   = "${aci_tenant.tenant_for_bridge_domain.id}"
+  tenant_dn   = aci_tenant.tenant_for_bridge_domain.id
   name        = "test_tf_bd"
   description = "This bridge domain is created by terraform ACI provider"
   mac         = "00:22:BD:F8:19:FF"

--- a/examples/demo_examples/contract.tf
+++ b/examples/demo_examples/contract.tf
@@ -4,7 +4,7 @@ resource "aci_tenant" "tenant_for_contract" {
 }
 
 resource "aci_contract" "democontract" {
-  tenant_dn   = "${aci_tenant.tenant_for_contract.id}"
+  tenant_dn   = aci_tenant.tenant_for_contract.id
   name        = "test_tf_contract"
   description = "This contract is created by terraform ACI provider"
   scope       = "context"

--- a/examples/demo_examples/entry.tf
+++ b/examples/demo_examples/entry.tf
@@ -4,13 +4,13 @@ resource "aci_tenant" "tenant_for_entry" {
 }
 
 resource "aci_filter" "filter_for_entry" {
-  tenant_dn   = "${aci_tenant.tenant_for_entry.id}"
+  tenant_dn   = aci_tenant.tenant_for_entry.id
   name        = "filter_for_entry"
   description = "This filter is created by terraform ACI provider."
 }
 
 resource "aci_entry" "demoentry" {
-  filter_dn   = "${aci_filter.filter_for_entry.id}"
+  filter_dn   = aci_filter.filter_for_entry.id
   name        = "test_tf_entry"
   description = "This entry is created by terraform ACI provider"
 }

--- a/examples/demo_examples/epg.tf
+++ b/examples/demo_examples/epg.tf
@@ -3,12 +3,12 @@ resource "aci_tenant" "tenant_for_epg" {
   description = "This tenant is created by terraform ACI provider"
 }
 resource "aci_app_profile" "app_profile_for_epg" {
-  tenant_dn   = "${aci_tenant.tenant_for_epg.id}"
+  tenant_dn   = aci_tenant.tenant_for_epg.id
   name        = "ap_for_epg"
   description = "This app profile is created by terraform ACI providers"
 }
 resource "aci_epg" "demoepg" {
-  application_profile_dn = "${aci_app_profile.app_profile_for_epg.id}"
+  application_profile_dn = aci_app_profile.app_profile_for_epg.id
   name                   = "tf_test_epg"
   description            = "This epg is created by terraform ACI providers"
 }

--- a/examples/demo_examples/filter.tf
+++ b/examples/demo_examples/filter.tf
@@ -4,7 +4,7 @@ resource "aci_tenant" "tenant_for_filter" {
 }
 
 resource "aci_filter" "demofilter" {
-  tenant_dn   = "${aci_tenant.tenant_for_filter.id}"
+  tenant_dn   = aci_tenant.tenant_for_filter.id
   name        = "test_tf_filter"
   description = "This filter is created by terraform ACI provider."
 }

--- a/examples/demo_examples/subject.tf
+++ b/examples/demo_examples/subject.tf
@@ -4,7 +4,7 @@ resource "aci_tenant" "tenant_for_subject" {
 }
 
 resource "aci_contract" "contract_for_subject" {
-  tenant_dn   = "${aci_tenant.tenant_for_subject.id}"
+  tenant_dn   = aci_tenant.tenant_for_subject.id
   name        = "contract_for_subject"
   description = "This contract is created by terraform ACI provider"
   scope       = "context"
@@ -12,7 +12,7 @@ resource "aci_contract" "contract_for_subject" {
 }
 
 resource "aci_subject" "demosubject" {
-  contract_dn = "${aci_contract.contract_for_subject.id}"
+  contract_dn = aci_contract.contract_for_subject.id
   name        = "test_tf_subject"
   description = "This subject is created by terraform ACI provider"
 }

--- a/examples/demo_examples/subnet.tf
+++ b/examples/demo_examples/subnet.tf
@@ -4,7 +4,7 @@ resource "aci_tenant" "tenant_for_subnet" {
 }
 
 resource "aci_bridge_domain" "bd_for_subnet" {
-  tenant_dn   = "${aci_tenant.tenant_for_subnet.id}"
+  tenant_dn   = aci_tenant.tenant_for_subnet.id
   name        = "bd_for_subnet"
   description = "This bridge domain is created by terraform ACI provider"
   mac         = "00:22:BD:F8:19:FF"
@@ -12,7 +12,7 @@ resource "aci_bridge_domain" "bd_for_subnet" {
 
 resource "aci_subnet" "demosubnet" {
   name             = "10.0.3.28/27"
-  bridge_domain_dn = "${aci_bridge_domain.bd_for_subnet.id}"
+  bridge_domain_dn = aci_bridge_domain.bd_for_subnet.id
   ip_address       = "10.0.3.28/27"
   scope            = ["private"]
   description      = "This subject is created by terraform"

--- a/examples/entry/entry.tf
+++ b/examples/entry/entry.tf
@@ -4,13 +4,13 @@ resource "aci_tenant" "tenant_for_entry" {
 }
 
 resource "aci_filter" "filter_for_entry" {
-  tenant_dn   = "${aci_tenant.tenant_for_entry.id}"
+  tenant_dn   = aci_tenant.tenant_for_entry.id
   name        = "filter_for_entry"
   description = "This filter is created by terraform ACI provider."
 }
 
 resource "aci_filter_entry" "demoentry" {
-  filter_dn     = "${aci_filter.filter_for_entry.id}"
+  filter_dn     = aci_filter.filter_for_entry.id
   name          = "test_tf_entry"
   description   = "This entry is created by terraform ACI provider"
   apply_to_frag = "no"

--- a/examples/epg/bd.tf
+++ b/examples/epg/bd.tf
@@ -1,6 +1,6 @@
 
 resource "aci_bridge_domain" "bd_for_rel" {
-  tenant_dn   = "${aci_tenant.tenant_for_epg.id}"
+  tenant_dn   = aci_tenant.tenant_for_epg.id
   name        = "test_tf_bd_rel"
   description = "This bridge domain is created by terraform ACI provider"
   mac         = "00:22:BD:F8:19:FF"

--- a/examples/epg/contract.tf
+++ b/examples/epg/contract.tf
@@ -4,7 +4,7 @@ resource "aci_tenant" "tenant_for_contract" {
 }
 
 resource "aci_contract" "rs_prov_contract" {
-  tenant_dn                = "${aci_tenant.tenant_for_contract.id}"
+  tenant_dn                = aci_tenant.tenant_for_contract.id
   name                     = "rs_prov_contract"
   description              = "This contract is created by terraform ACI provider"
   scope                    = "context"
@@ -13,7 +13,7 @@ resource "aci_contract" "rs_prov_contract" {
   relation_vz_rs_graph_att = "test3" # Relation to vnsAbsGraph class. Cardinality - N_TO_ONE
 }
 resource "aci_contract" "rs_cons_contract" {
-  tenant_dn                = "${aci_tenant.tenant_for_contract.id}"
+  tenant_dn                = aci_tenant.tenant_for_contract.id
   name                     = "rs_cons_contract"
   description              = "This contract is created by terraform ACI provider"
   scope                    = "context"
@@ -22,7 +22,7 @@ resource "aci_contract" "rs_cons_contract" {
   relation_vz_rs_graph_att = "test3" # Relation to vnsAbsGraph class. Cardinality - N_TO_ONE
 }
 resource "aci_contract" "intra_epg_contract" {
-  tenant_dn                = "${aci_tenant.tenant_for_contract.id}"
+  tenant_dn                = aci_tenant.tenant_for_contract.id
   name                     = "intra_epg_contract"
   description              = "This contract is created by terraform ACI provider"
   scope                    = "context"

--- a/examples/epg/epg.tf
+++ b/examples/epg/epg.tf
@@ -4,20 +4,20 @@ resource "aci_tenant" "tenant_for_epg" {
 }
 
 resource "aci_application_profile" "app_profile_for_epg" {
-  tenant_dn   = "${aci_tenant.tenant_for_epg.id}"
+  tenant_dn   = aci_tenant.tenant_for_epg.id
   name        = "ap_for_epg"
   description = "This app profile is created by terraform ACI providers"
 }
 
 resource "aci_application_epg" "inherit_epg" {
-  application_profile_dn = "${aci_application_profile.app_profile_for_epg.id}"
+  application_profile_dn = aci_application_profile.app_profile_for_epg.id
   name                   = "inherit_epg"
   description            = "epg to create relation sec_inherited"
 
 }
 
 resource "aci_application_epg" "demoepg" {
-  application_profile_dn       = "${aci_application_profile.app_profile_for_epg.id}"
+  application_profile_dn       = aci_application_profile.app_profile_for_epg.id
   name                         = "tf_test_epg"
   description                  = "This epg is created by terraform ACI providers"
   flood_on_encap               = "disabled"
@@ -27,18 +27,18 @@ resource "aci_application_epg" "demoepg" {
   pc_enf_pref                  = "unenforced"
   pref_gr_memb                 = "exclude"
   prio                         = "unspecified"
-  relation_fv_rs_bd            = "${aci_bridge_domain.bd_for_rel.id}"      # Relation to fvBD class. Cardinality - N_TO_ONE.
-  relation_fv_rs_cust_qos_pol  = "${aci_rest.rest_qos_custom_pol.id}"      # Relation to qosCustomPol class. Cardinality - N_TO_ONE.
-  relation_fv_rs_dom_att       = ["${aci_rest.rest_infra_domp.id}"]        # Relation to infraDomP class. Cardinality - N_TO_M.
+  relation_fv_rs_bd            = aci_bridge_domain.bd_for_rel.id      # Relation to fvBD class. Cardinality - N_TO_ONE.
+  relation_fv_rs_cust_qos_pol  = aci_rest.rest_qos_custom_pol.id      # Relation to qosCustomPol class. Cardinality - N_TO_ONE.
+  relation_fv_rs_dom_att       = [aci_rest.rest_infra_domp.id]        # Relation to infraDomP class. Cardinality - N_TO_M.
   relation_fv_rs_fc_path_att   = ["testfabric"]                            # Relation to fabricPathEp class. Cardinality - N_TO_M.
-  relation_fv_rs_prov          = ["${aci_contract.rs_prov_contract.id}"]   # Relation to vzBrCP class. Cardinality - N_TO_M.
-  relation_fv_rs_cons_if       = ["${aci_rest.rest_vz_cons_if.id}"]        # Relation to vzCPIf class. Cardinality - N_TO_M.
-  relation_fv_rs_sec_inherited = ["${aci_application_epg.inherit_epg.id}"] # Relation to fvEPg class. Cardinality - N_TO_M.
+  relation_fv_rs_prov          = [aci_contract.rs_prov_contract.id]   # Relation to vzBrCP class. Cardinality - N_TO_M.
+  relation_fv_rs_cons_if       = [aci_rest.rest_vz_cons_if.id]        # Relation to vzCPIf class. Cardinality - N_TO_M.
+  relation_fv_rs_sec_inherited = [aci_application_epg.inherit_epg.id] # Relation to fvEPg class. Cardinality - N_TO_M.
   relation_fv_rs_node_att      = ["testnodeatt"]                           # Relation to fabricNode class. Cardinality - N_TO_M.
-  relation_fv_rs_dpp_pol       = "${aci_rest.rest_qos_dpp_pol.id}"         # Relation to qosDppPol class. Cardinality - N_TO_ONE.
-  relation_fv_rs_cons          = ["${aci_contract.rs_cons_contract.id}"]   # Relation to vzBrCP class. Cardinality - N_TO_M.
-  relation_fv_rs_trust_ctrl    = "${aci_rest.rest_trust_ctrl_pol.id}"      # Relation to fhsTrustCtrlPol class. Cardinality - N_TO_ONE.
-  relation_fv_rs_prot_by       = ["${aci_rest.rest_taboo_con.id}"]         # Relation to vzTaboo class. Cardinality - N_TO_M.
-  relation_fv_rs_aepg_mon_pol = "${aci_rest.rest_mon_epg_pol.id}"         # Relation to monEPGPol class. Cardinality - N_TO_ONE.
-  relation_fv_rs_intra_epg     = ["${aci_contract.intra_epg_contract.id}"] # Relation to vzBrCP class. Cardinality - N_TO_M.
+  relation_fv_rs_dpp_pol       = aci_rest.rest_qos_dpp_pol.id         # Relation to qosDppPol class. Cardinality - N_TO_ONE.
+  relation_fv_rs_cons          = [aci_contract.rs_cons_contract.id]   # Relation to vzBrCP class. Cardinality - N_TO_M.
+  relation_fv_rs_trust_ctrl    = aci_rest.rest_trust_ctrl_pol.id      # Relation to fhsTrustCtrlPol class. Cardinality - N_TO_ONE.
+  relation_fv_rs_prot_by       = [aci_rest.rest_taboo_con.id]         # Relation to vzTaboo class. Cardinality - N_TO_M.
+  relation_fv_rs_aepg_mon_pol = aci_rest.rest_mon_epg_pol.id         # Relation to monEPGPol class. Cardinality - N_TO_ONE.
+  relation_fv_rs_intra_epg     = [aci_contract.intra_epg_contract.id] # Relation to vzBrCP class. Cardinality - N_TO_M.
 }

--- a/examples/filter/filter.tf
+++ b/examples/filter/filter.tf
@@ -4,21 +4,21 @@ resource "aci_tenant" "tenant_for_filter" {
 }
 
 resource "aci_filter" "demofilter" {
-  tenant_dn                      = "${aci_tenant.tenant_for_filter.id}"
+  tenant_dn                      = aci_tenant.tenant_for_filter.id
   name                           = "test_tf_filter"
   description                    = "This filter is created by terraform ACI provider."
   relation_vz_rs_filt_graph_att  = "testinterm"                  # Relation to  vnsInTerm class. Cardinality - N_TO_ONE.
-  relation_vz_rs_fwd_r_flt_p_att = "${aci_filter.fwd_filter.id}" # Relation to  vzAFilterableUnit class. Cardinality - N_TO_ONE.
-  relation_vz_rs_rev_r_flt_p_att = "${aci_filter.rev_filter.id}" # Relation to  vzAFilterableUnit class. Cardinality - N_TO_ONE.
+  relation_vz_rs_fwd_r_flt_p_att = aci_filter.fwd_filter.id # Relation to  vzAFilterableUnit class. Cardinality - N_TO_ONE.
+  relation_vz_rs_rev_r_flt_p_att = aci_filter.rev_filter.id # Relation to  vzAFilterableUnit class. Cardinality - N_TO_ONE.
 }
 
 resource "aci_filter" "fwd_filter" {
-  tenant_dn   = "${aci_tenant.tenant_for_filter.id}"
+  tenant_dn   = aci_tenant.tenant_for_filter.id
   name        = "test_tf_filter"
   description = "This filter is created by terraform ACI provider."
 }
 resource "aci_filter" "rev_filter" {
-  tenant_dn   = "${aci_tenant.tenant_for_filter.id}"
+  tenant_dn   = aci_tenant.tenant_for_filter.id
   name        = "test_tf_filter"
   description = "This filter is created by terraform ACI provider."
 }

--- a/examples/imported_contract/main.tf
+++ b/examples/imported_contract/main.tf
@@ -11,9 +11,9 @@ resource "aci_tenant" "terraform_ten" {
 
 resource "aci_imported_contract" "example" {
 
-  tenant_dn = "${aci_tenant.terraform_ten.id}"
+  tenant_dn = aci_tenant.terraform_ten.id
   name       = "example"
   annotation = "example"
   name_alias = "example"
-  relation_vz_rs_if = "${aci_tenant.terraform_ten.id}"
+  relation_vz_rs_if = aci_tenant.terraform_ten.id
 }

--- a/examples/inline_entry/entry_main.tf
+++ b/examples/inline_entry/entry_main.tf
@@ -14,7 +14,7 @@ resource "aci_tenant" "tenentcheck" {
 }
 
 resource "aci_contract" "democontract" {
-  tenant_dn   = "${aci_tenant.tenentcheck.id}"
+  tenant_dn   = aci_tenant.tenentcheck.id
   name        = "test_tf_contract"
   description = "ThiscontractiscreatedbyterraformACIprovider"
   scope       = "context"

--- a/examples/leaf_profile/entity_profile.tf
+++ b/examples/leaf_profile/entity_profile.tf
@@ -4,7 +4,7 @@ resource "aci_attachable_access_entity_profile" "test_ep" {
 }
 
 resource "aci_vlan_encapsulationfor_vxlan_traffic" "test_vxlan_traffic" {
-    attachable_access_entity_profile_dn = "${aci_attachable_access_entity_profile.test_ep.id}"
+    attachable_access_entity_profile_dn = aci_attachable_access_entity_profile.test_ep.id
     name = "test_vxlan"
   
 }

--- a/examples/leaf_profile/ospf_policy.tf
+++ b/examples/leaf_profile/ospf_policy.tf
@@ -4,6 +4,6 @@ resource "aci_tenant" "test_tenant" {
 }
 
 resource "aci_ospf_interface_policy" "test_ospf" {
-  tenant_dn = "${aci_tenant.test_tenant.id}"
+  tenant_dn = aci_tenant.test_tenant.id
   name = "tf_ospf"
 }

--- a/examples/leaf_profile/port_block.tf
+++ b/examples/leaf_profile/port_block.tf
@@ -1,4 +1,4 @@
 resource "aci_access_port_block" "test_port_block" {
-  access_port_selector_dn = "${aci_access_port_selector.test_selector.id}"
+  access_port_selector_dn = aci_access_port_selector.test_selector.id
   name = "tf_test_block"
 }

--- a/examples/leaf_profile/port_selector.tf
+++ b/examples/leaf_profile/port_selector.tf
@@ -1,5 +1,5 @@
 resource "aci_access_port_selector" "test_selector" {
-    leaf_interface_profile_dn = "${aci_leaf_interface_profile.test_leaf_profile.id}"
+    leaf_interface_profile_dn = aci_leaf_interface_profile.test_leaf_profile.id
     name = "tf_test"
     access_port_selector_type = "default"
   

--- a/examples/leaf_profile/retention_policy.tf
+++ b/examples/leaf_profile/retention_policy.tf
@@ -1,5 +1,5 @@
 resource "aci_end_point_retention_policy" "test_ret_policy" {
-    tenant_dn = "${aci_tenant.test_tenant.id}"
+    tenant_dn = aci_tenant.test_tenant.id
     name = "tf_test"
   
 }

--- a/examples/relations_concrete/main.tf
+++ b/examples/relations_concrete/main.tf
@@ -11,13 +11,13 @@ resource "aci_tenant" "tenant_for_epg" {
 }
 
 resource "aci_application_profile" "app_profile_for_epg" {
-  tenant_dn   = "${aci_tenant.tenant_for_epg.id}"
+  tenant_dn   = aci_tenant.tenant_for_epg.id
   name        = "ap_for_epg"
   description = "This app profile is created by terraform ACI providers"
 }
 
 resource "aci_application_epg" "inherit_epg" {
-  application_profile_dn = "${aci_application_profile.app_profile_for_epg.id}"
+  application_profile_dn = aci_application_profile.app_profile_for_epg.id
   name                   = "inherit_epg"
   description            = "epg to create relation sec_inherited"
 
@@ -33,7 +33,7 @@ resource "aci_epg_to_static_path" "epg_to_stat_path" {
 }
 
 resource "aci_l3_outside" "fool3_outside" {
-  tenant_dn      = "${aci_tenant.tenant_for_epg.id}"
+  tenant_dn      = aci_tenant.tenant_for_epg.id
   name           = "demo_l3out"
   annotation     = "tag_l3out"
   name_alias     = "alias_out"
@@ -41,7 +41,7 @@ resource "aci_l3_outside" "fool3_outside" {
 }
 
 resource "aci_logical_node_profile" "foological_node_profile" {
-  l3_outside_dn = "${aci_l3_outside.fool3_outside.id}"
+  l3_outside_dn = aci_l3_outside.fool3_outside.id
   description   = "sample logical node profile"
   name          = "demo_node"
   annotation    = "tag_node"
@@ -53,7 +53,7 @@ resource "aci_logical_node_profile" "foological_node_profile" {
 
 resource "aci_logical_node_to_fabric_node" "example" {
 
-  logical_node_profile_dn  = "${aci_logical_node_profile.foological_node_profile.id}"
+  logical_node_profile_dn  = aci_logical_node_profile.foological_node_profile.id
   tdn  = "topology/pod-1/node-101"
   annotation  = "example"
   rtr_id  = "12"

--- a/examples/subject/filter.tf
+++ b/examples/subject/filter.tf
@@ -4,7 +4,7 @@ resource "aci_tenant" "tenant_for_filter" {
 }
 
 resource "aci_filter" "subj_filter" {
-  tenant_dn   = "${aci_tenant.tenant_for_filter.id}"
+  tenant_dn   = aci_tenant.tenant_for_filter.id
   name        = "test_tf_filter"
   description = "This filter is created by terraform ACI provider."
 }

--- a/examples/subject/subject.tf
+++ b/examples/subject/subject.tf
@@ -4,7 +4,7 @@ resource "aci_tenant" "tenant_for_subject" {
 }
 
 resource "aci_contract" "contract_for_subject" {
-  tenant_dn   = "${aci_tenant.tenant_for_subject.id}"
+  tenant_dn   = aci_tenant.tenant_for_subject.id
   name        = "contract_for_subject"
   description = "This contract is created by terraform ACI provider"
   scope       = "context"
@@ -12,7 +12,7 @@ resource "aci_contract" "contract_for_subject" {
 }
 
 resource "aci_contract_subject" "demosubject" {
-  contract_dn                   = "${aci_contract.contract_for_subject.id}"
+  contract_dn                   = aci_contract.contract_for_subject.id
   name                          = "test_tf_subject"
   description                   = "This subject is created by terraform ACI provider"
   cons_match_t                  = "None"
@@ -20,6 +20,6 @@ resource "aci_contract_subject" "demosubject" {
   prov_match_t                  = "None"
   rev_flt_ports                 = "no"
   target_dscp                   = "unspecified"
-  relation_vz_rs_subj_graph_att = "${aci_rest.rest_abs_graph.id}"  # Relation to vnsAbsGraph class. Cardinality - N_TO_ONE.
-  relation_vz_rs_subj_filt_att  = ["${aci_filter.subj_filter.id}"] # Relation to vzFilter class. Cardinality - N_TO_M.
+  relation_vz_rs_subj_graph_att = aci_rest.rest_abs_graph.id  # Relation to vnsAbsGraph class. Cardinality - N_TO_ONE.
+  relation_vz_rs_subj_filt_att  = [aci_filter.subj_filter.id] # Relation to vzFilter class. Cardinality - N_TO_M.
 }

--- a/examples/subnet/subnet.tf
+++ b/examples/subnet/subnet.tf
@@ -4,21 +4,21 @@ resource "aci_tenant" "tenant_for_subnet" {
 }
 
 resource "aci_bridge_domain" "bd_for_subnet" {
-  tenant_dn   = "${aci_tenant.tenant_for_subnet.id}"
+  tenant_dn   = aci_tenant.tenant_for_subnet.id
   name        = "bd_for_subnet"
   description = "This bridge domain is created by terraform ACI provider"
   mac         = "00:22:BD:F8:19:FF"
 }
 
 resource "aci_subnet" "demosubnet" {
-  parent_dn                           = "${aci_bridge_domain.bd_for_subnet.id}"
+  parent_dn                           = aci_bridge_domain.bd_for_subnet.id
   ip                                  = "10.0.3.28/27"
   scope                               = ["private"]
   description                         = "This subject is created by terraform"
   ctrl                                = ["unspecified"]
   preferred                           = "no"
   virtual                             = "yes"
-  relation_fv_rs_bd_subnet_to_profile = "${aci_rest.rest_rt_ctrl_profile.id}" # Relation to rtctrlProfile class. Cardinality - N_TO_ONE.
-  relation_fv_rs_bd_subnet_to_out     = ["${aci_rest.rest_l3_ext_out.id}"]    # Relation to l3extOut class. Cardinality - N_TO_M.
-  relation_fv_rs_nd_pfx_pol           = "${aci_rest.rest_nd_pfx_pol.id}"      # Relation to ndPfxPol class. Cardinality - N_TO_ONE.
+  relation_fv_rs_bd_subnet_to_profile = aci_rest.rest_rt_ctrl_profile.id # Relation to rtctrlProfile class. Cardinality - N_TO_ONE.
+  relation_fv_rs_bd_subnet_to_out     = [aci_rest.rest_l3_ext_out.id]    # Relation to l3extOut class. Cardinality - N_TO_M.
+  relation_fv_rs_nd_pfx_pol           = aci_rest.rest_nd_pfx_pol.id      # Relation to ndPfxPol class. Cardinality - N_TO_ONE.
 }

--- a/examples/tenant/filter.tf
+++ b/examples/tenant/filter.tf
@@ -4,13 +4,13 @@ resource "aci_tenant" "tenant_for_filter" {
 }
 
 resource "aci_filter" "deny_rule_filter1" {
-  tenant_dn   = "${aci_tenant.tenant_for_filter.id}"
+  tenant_dn   = aci_tenant.tenant_for_filter.id
   name        = "test_tf_filter"
   description = "This filter is created by terraform ACI provider."
 }
 
 resource "aci_filter" "deny_rule_filter2" {
-  tenant_dn   = "${aci_tenant.tenant_for_filter.id}"
+  tenant_dn   = aci_tenant.tenant_for_filter.id
   name        = "test_tf_filter2"
   description = "This filter is created by terraform ACI provider."
 }

--- a/examples/tenant/main.tf
+++ b/examples/tenant/main.tf
@@ -17,8 +17,8 @@ provider "aci" {
 resource "aci_tenant" "demotenant" {
   name                          = "tf_test_tenant"
   description                   = "This tenant is created by terraform"
-  relation_fv_rs_tn_deny_rule   = ["${aci_filter.deny_rule_filter1.id}", "${aci_filter.deny_rule_filter2.id}"] # Relation to vzFilter class. Cardinality - N_TO_M.
-  relation_fv_rs_tenant_mon_pol = "${aci_rest.rest_mon_epg_pol.id}"                                            # Relation to monEPGPol class. Cardinality - N_TO_ONE.
+  relation_fv_rs_tn_deny_rule   = [aci_filter.deny_rule_filter1.id, aci_filter.deny_rule_filter2.id] # Relation to vzFilter class. Cardinality - N_TO_M.
+  relation_fv_rs_tenant_mon_pol = aci_rest.rest_mon_epg_pol.id                                            # Relation to monEPGPol class. Cardinality - N_TO_ONE.
 }
 
 resource "aci_tenant" "test_tenant" {


### PR DESCRIPTION
Example:

provider_profile_dn = "${aci_provider_profile.example.id}"

to:

provider_profile_dn = aci_provider_profile.example.id