### PR TITLE
Expand fabricpath to include support for vPC

### DIFF
--- a/aci/data_source_aci_fabricpathep.go
+++ b/aci/data_source_aci_fabricpathep.go
@@ -16,6 +16,12 @@ func dataSourceAciFabricPathEndpoint() *schema.Resource {
 		SchemaVersion: 1,
 
 		Schema: AppendBaseAttrSchema(map[string]*schema.Schema{
+			"vpc": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"pod_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
@@ -62,11 +68,18 @@ func setFabricPathEndpointAttributes(fabricPathEp *models.FabricPathEndpoint, d 
 func dataSourceAciFabricPathEndpointRead(d *schema.ResourceData, m interface{}) error {
 	aciClient := m.(*client.Client)
 
+	vpc := d.Get("vpc").(bool)
 	name := d.Get("name").(string)
 	podID := d.Get("pod_id").(string)
 	nodeID := d.Get("node_id").(string)
 
-	pDN := fmt.Sprintf("topology/pod-%s/paths-%s", podID, nodeID)
+	var pDN string
+
+	if vpc {
+		pDN = fmt.Sprintf("topology/pod-%s/protpaths-%s", podID, nodeID)
+	} else {
+		pDN = fmt.Sprintf("topology/pod-%s/paths-%s", podID, nodeID)
+	}
 
 	rn := fmt.Sprintf("pathep-[%s]", name)
 

--- a/website/docs/d/fabric_path_ep.html.markdown
+++ b/website/docs/d/fabric_path_ep.html.markdown
@@ -19,12 +19,20 @@ data "aci_fabric_path_ep" "example" {
   name    = "eth1/7"
 }
 
+data "aci_fabric_path_ep" "vpc_example" {
+  vpc     = true
+  pod_id  = "1"
+  node_id = "101-102"
+  name    = aci_leaf_access_bundle_policy_group.example.name
+}
+
 ```
 
 ## Argument Reference ##
 * `pod_id` - (Required) pod ID for Object fabric path endpoint.
 * `node_id` - (Required) node ID for Object fabric path endpoint.
 * `name` - (Required) name of Object fabric path endpoint.
+* `vpc` - (Optional) Boolean, set to true if path is for a vPC interface
 
 
 


### PR DESCRIPTION
The data source aci_fabric_path_ep currently doesn't support VPC lookups. 

This simple change adds an optional Bool called 'vpc' that can be supplied to the data source. The bool defaults to false to ensure backwards compatibility. 

Functionality after merge:



```
data "aci_fabric_path_ep" "path" {
  pod_id  = "1"
  node_id = "101"
  name    = "eth1/31"
}

data "aci_fabric_path_ep" "pcpath" {
  vpc     = false
  pod_id  = "1"
  node_id = "102"
  name    = "Example-PC"
}

data "aci_fabric_path_ep" "vpcpath" {
  vpc     = true
  pod_id  = "1"
  node_id = "101-102"
  name    = "Example-vPC"
}

output "path" {
  value = data.aci_fabric_path_ep.path.id
}

output "pcpath" {
  value = data.aci_fabric_path_ep.pcpath.id
}

output "vpcpath" {
  value = data.aci_fabric_path_ep.vpcpath.id
}
```

When terraform plan is then run we get the following output now:

```
Changes to Outputs:
  + path    = "topology/pod-1/paths-101/pathep-[eth1/31]"
  + pcpath  = "topology/pod-1/paths-102/pathep-[Example-PC]"
  + vpcpath = "topology/pod-1/protpaths-101-102/pathep-[Example-vPC]"
```