### PR TITLE
fixed aci_vlan_pool doc issue

### DIFF
--- a/website/docs/r/vlan_pool.html.markdown
+++ b/website/docs/r/vlan_pool.html.markdown
@@ -24,7 +24,7 @@ resource "aci_vlan_pool" "example" {
 ```
 ## Argument Reference ##
 * `name` - (Required) name of Object vlan_pool.
-* `alloc_mode` - (Optional) allocation mode.
+* `alloc_mode` - (Required) allocation mode.
 Allowed values: "dynamic", "static"
 * `annotation` - (Optional) annotation for object vlan_pool.
 * `name_alias` - (Optional) name_alias for object vlan_pool.


### PR DESCRIPTION
Current documentation says that alloc_mode argument for aci_vlan_pool is optional. Actually it is required:
```
$ tf plan                                                                                   

Error: Missing required argument

  on vlan_pools.tf line 1, in resource "aci_vlan_pool" "foo_pool":
   1: resource "aci_vlan_pool" "foo_pool" {

The argument "alloc_mode" is required, but no definition was found.
```
