### PR TITLE
Fix warning about annotation type mismatch

### DIFF
--- a/aci/base_attr_schema.go
+++ b/aci/base_attr_schema.go
@@ -13,7 +13,10 @@ func GetBaseAttrSchema() map[string]*schema.Schema {
 		"annotation": &schema.Schema{
 			Type:     schema.TypeString,
 			Optional: true,
-			Default:  "orchestrator:terraform",
+			Computed: true,
+			DefaultFunc: func() (interface{}, error) {
+				return "orchestrator:terraform", nil
+			},
 		},
 	}
 }


### PR DESCRIPTION
When refreshing state for a resource without explicitly specifying the annotation argument the following warning is logged:

`
2021/04/16 14:18:20 [WARN] Provider "registry.terraform.io/ciscodevnet/aci" produced an invalid plan for aci_tenant.XXX, but we are tolerating it because it is using the legacy plugin SDK.
    The following problems may be the cause of any confusing errors from downstream operations:
      - .annotation: planned value cty.StringVal("orchestrator:terraform") does not match config value cty.NullVal(cty.String)
`

This seems to be a limitation related to the SDK version in use, when a schema attribute has both `Optional` and `Default` behaviors applied. As a workaround we can use a `DefaultFunc` instead of `Default` to provide a default value and use `Computed: True`.