### PR TITLE
corrected some mistakes for number ranges and formatting

### DIFF
--- a/website/docs/r/aaa_domain.html.markdown
+++ b/website/docs/r/aaa_domain.html.markdown
@@ -7,6 +7,7 @@ description: |-
 ---
 
 # aci_aaa_domain #
+
 Manages ACI aaa Domain
 
 ## Example Usage ##
@@ -14,32 +15,28 @@ Manages ACI aaa Domain
 ```hcl
 
 resource "aci_aaa_domain" "example" {
-  name  = "example"
-  annotation  = "example"
-  name_alias  = "example"
+  name        = "example"
+  annotation  = "tag_aaa"
+  name_alias  = "alias_aaa"
 }
 
 ```
 
-
 ## Argument Reference ##
+
 * `name` - (Required) name of Object aaa domain.
 * `annotation` - (Optional) annotation for object aaa domain.
 * `name_alias` - (Optional) name_alias for object aaa domain.
 
+## Attribute Reference ##
 
-
-## Attribute Reference
-
-The only attribute that this resource exports is the `id`, which is set to the
-Dn of the aaa domain.
+The only attribute that this resource exports is the `id`, which is set to the Dn of the aaa domain.
 
 ## Importing ##
 
 An existing aaa domain can be [imported][docs-import] into this resource via its Dn, via the following command:
-[docs-import]: https://www.terraform.io/docs/import/index.html
+[docs-import]: <https://www.terraform.io/docs/import/index.html>
 
-
-```
+```bash
 terraform import aci_aaa_domain.example <Dn>
 ```

--- a/website/docs/r/any.html.markdown
+++ b/website/docs/r/any.html.markdown
@@ -7,36 +7,35 @@ description: |-
 ---
 
 # aci_any #
+
 Manages ACI Any
 
 ## Example Usage ##
 
 ```hcl
-	resource "aci_any" "fooany" {
-		vrf_dn       = "${aci_vrf.example.id}"
-		description  = "%s"
-		annotation   = "tag_any"
-		match_t      = "%s"
-		name_alias   = "alias_any"
-		pref_gr_memb = "disabled"
-	}
+resource "aci_any" "example_vzany" {
+  vrf_dn       = aci_vrf.example.id
+  description  = "vzAny Description"
+  annotation   = "tag_any"
+  match_t      = "AtleastOne"
+  name_alias   = "alias_any"
+  pref_gr_memb = "disabled"
+}
 ```
+
 ## Argument Reference ##
+
 * `vrf_dn` - (Required) Distinguished name of parent VRF object.
 * `annotation` - (Optional) annotation for object any.
 * `match_t` - (Optional) Represents the provider label match criteria. Allowed values are "All", "None", "AtmostOne" and "AtleastOne". Default value is "AtleastOne".
 * `name_alias` - (Optional) name_alias for object any.
 * `pref_gr_memb` - (Optional) Represents parameter used to determine if EPgs can be divided in a the context can be divided in two subgroups. Allowed values are "disabled" and "enabled". Default is "disabled".
 
-* `relation_vz_rs_any_to_cons` - (Optional) Relation to class vzBrCP. Cardinality - N_TO_M. Type - Set of String.
-                
-* `relation_vz_rs_any_to_cons_if` - (Optional) Relation to class vzCPIf. Cardinality - N_TO_M. Type - Set of String.
-                
-* `relation_vz_rs_any_to_prov` - (Optional) Relation to class vzBrCP. Cardinality - N_TO_M. Type - Set of String.
-                
+* `relation_vz_rs_any_to_cons` - (Optional) Relation to class vzBrCP. Cardinality - N_TO_M. Type - [Set of String].
+* `relation_vz_rs_any_to_cons_if` - (Optional) Relation to class vzCPIf. Cardinality - N_TO_M. Type - [Set of String].
+* `relation_vz_rs_any_to_prov` - (Optional) Relation to class vzBrCP. Cardinality - N_TO_M. Type - [Set of String].
 
-
-## Attribute Reference
+## Attribute Reference ##
 
 The only attribute that this resource exports is the `id`, which is set to the
 Dn of the Any.
@@ -44,9 +43,8 @@ Dn of the Any.
 ## Importing ##
 
 An existing Any can be [imported][docs-import] into this resource via its Dn, via the following command:
-[docs-import]: https://www.terraform.io/docs/import/index.html
+[docs-import]: <https://www.terraform.io/docs/import/index.html>
 
-
-```
+```bash
 terraform import aci_any.example <Dn>
 ```

--- a/website/docs/r/attachable_access_entity_profile.html.markdown
+++ b/website/docs/r/attachable_access_entity_profile.html.markdown
@@ -7,28 +7,29 @@ description: |-
 ---
 
 # aci_attachable_access_entity_profile #
+
 Manages ACI Attachable Access Entity Profile
 
 ## Example Usage ##
 
 ```hcl
-	resource "aci_attachable_access_entity_profile" "fooattachable_access_entity_profile" {
-		description = "%s"
-		name        = "demo_entity_prof"
-		annotation  = "tag_entity"
-		name_alias  = "%s"
-	}
+resource "aci_attachable_access_entity_profile" "example" {
+  description = "AAEP description"
+  name        = "demo_entity_prof"
+  annotation  = "tag_entity"
+  name_alias  = "alias_entity"
+}
 ```
+
 ## Argument Reference ##
+
 * `name` - (Required) name of Object attachable_access_entity_profile.
 * `annotation` - (Optional) annotation for object attachable_access_entity_profile.
 * `name_alias` - (Optional) name_alias for object attachable_access_entity_profile.
 
-* `relation_infra_rs_dom_p` - (Optional) Relation to class infraADomP. Cardinality - N_TO_M. Type - Set of String.
-                
+* `relation_infra_rs_dom_p` - (Optional) Relation to class infraADomP. Cardinality - N_TO_M. Type - [Set of String].
 
-
-## Attribute Reference
+## Attribute Reference ##
 
 The only attribute that this resource exports is the `id`, which is set to the
 Dn of the Attachable Access Entity Profile.
@@ -36,9 +37,8 @@ Dn of the Attachable Access Entity Profile.
 ## Importing ##
 
 An existing Attachable Access Entity Profile can be [imported][docs-import] into this resource via its Dn, via the following command:
-[docs-import]: https://www.terraform.io/docs/import/index.html
+[docs-import]: <https://www.terraform.io/docs/import/index.html>
 
-
-```
+```bash
 terraform import aci_attachable_access_entity_profile.example <Dn>
 ```

--- a/website/docs/r/cdp_interface_policy.html.markdown
+++ b/website/docs/r/cdp_interface_policy.html.markdown
@@ -7,30 +7,28 @@ description: |-
 ---
 
 # aci_cdp_interface_policy #
+
 Manages ACI CDP Interface Policy
 
 ## Example Usage ##
 
 ```hcl
 resource "aci_cdp_interface_policy" "example" {
-
-
-  name  = "example"
-  admin_st  = "example"
-  annotation  = "example"
-  name_alias  = "example"
+  name        = "example"
+  admin_st    = "enabled"
+  annotation  = "tag_cdp"
+  name_alias  = "alias_cdp"
 }
 ```
+
 ## Argument Reference ##
+
 * `name` - (Required) name of Object cdp_interface_policy.
-* `admin_st` - (Optional) administrative state
-Allowed values: "enabled", "disabled"
+* `admin_st` - (Optional) administrative state.  Allowed values: "enabled", "disabled".  Default value is "enabled".
 * `annotation` - (Optional) annotation for object cdp_interface_policy.
 * `name_alias` - (Optional) name_alias for object cdp_interface_policy.
 
-
-
-## Attribute Reference
+## Attribute Reference ##
 
 The only attribute that this resource exports is the `id`, which is set to the
 Dn of the CDP Interface Policy.
@@ -38,9 +36,8 @@ Dn of the CDP Interface Policy.
 ## Importing ##
 
 An existing CDP Interface Policy can be [imported][docs-import] into this resource via its Dn, via the following command:
-[docs-import]: https://www.terraform.io/docs/import/index.html
+[docs-import]: <https://www.terraform.io/docs/import/index.html>
 
-
-```
+```bash
 terraform import aci_cdp_interface_policy.example <Dn>
 ```

--- a/website/docs/r/fabric_if_pol.html.markdown
+++ b/website/docs/r/fabric_if_pol.html.markdown
@@ -7,26 +7,25 @@ description: |-
 ---
 
 # aci_fabric_if_pol #
+
 Manages ACI fabric if pol
 
 ## Example Usage ##
 
 ```hcl
-
 resource "aci_fabric_if_pol" "example" {
   name        = "example"
-  description = "hello"
+  description = "Link Level description"
   annotation  = "annotation"
   auto_neg    = "on"
   fec_mode    = "inherit"
-  name_alias  = "example"
+  name_alias  = "alias_ifpol"
   speed       = "inherit"
 }
-
 ```
 
-
 ## Argument Reference ##
+
 * `name` - (Required) name of Object fabric if pol.
 * `annotation` - (Optional) annotation for object fabric if pol.
 * `auto_neg` - (Optional) policy auto-negotiation. Allowed values: "on", "off"
@@ -35,9 +34,7 @@ resource "aci_fabric_if_pol" "example" {
 * `name_alias` - (Optional) name_alias for object fabric if pol.
 * `speed` - (Optional) port speed. Allowed values: "unknown", "100M", "1G", "10G", "25G", "40G", "50G", "100G","200G", "400G", "inherit".
 
-
-
-## Attribute Reference
+## Attribute Reference ##
 
 The only attribute that this resource exports is the `id`, which is set to the
 Dn of the Link Level Policy.
@@ -45,9 +42,8 @@ Dn of the Link Level Policy.
 ## Importing ##
 
 An existing Link Level Policy can be [imported][docs-import] into this resource via its Dn, via the following command:
-[docs-import]: https://www.terraform.io/docs/import/index.html
+[docs-import]: <https://www.terraform.io/docs/import/index.html>
 
-
-```
+```bash
 terraform import aci_fabric_if_pol.example <Dn>
 ```

--- a/website/docs/r/interface_fc_policy.html.markdown
+++ b/website/docs/r/interface_fc_policy.html.markdown
@@ -7,6 +7,7 @@ description: |-
 ---
 
 # aci_interface_fc_policy #
+
 Manages ACI Interface FC Policy
 
 ## Example Usage ##
@@ -15,30 +16,30 @@ Manages ACI Interface FC Policy
 resource "aci_interface_fc_policy" "example" {
   name         = "demo_policy"
   annotation   = "tag_if_policy"
-  automaxspeed = "auto"
+  automaxspeed = "32G"
   fill_pattern = "default"
   name_alias   = "demo_alias"
   port_mode    = "f"
   rx_bb_credit = "64"
   speed        = "auto"
-  trunk_mode   = "auto"
+  trunk_mode   = "trunk-off"
 }
 
 ```
+
 ## Argument Reference ##
+
 * `name` - (Required) name of Object interface_fc_policy.
 * `annotation` - (Optional) annotation for object interface_fc_policy.
 * `automaxspeed` - (Optional) automaxspeed for object interface_fc_policy.
 * `fill_pattern` - (Optional) Fill Pattern for native FC ports. Allowed values are "ARBFF" and "IDLE". Default is "IDLE".
 * `name_alias` - (Optional) name_alias for object interface_fc_policy.
 * `port_mode` - (Optional) In which mode Ports should be used. Allowed values are "f" and "np". Default is "f".
-* `rx_bb_credit` - (Optional) Receive buffer credits for native FC ports Range:(161 - 641). Default value is 64.
+* `rx_bb_credit` - (Optional) Receive buffer credits for native FC ports Range:(16 - 64). Default value is 64.
 * `speed` - (Optional) cpu or port speed. All the supported values are unknown, auto, 4G, 8G, 16G, 32G. Default value is auto.  
 * `trunk_mode` - (Optional) Trunking on/off for native FC ports. Allowed values are "un-init", "trunk-off", "trunk-on" and "auto".Default value is "trunk-off".
 
-
-
-## Attribute Reference
+## Attribute Reference ##
 
 The only attribute that this resource exports is the `id`, which is set to the
 Dn of the Interface FC Policy.
@@ -46,9 +47,8 @@ Dn of the Interface FC Policy.
 ## Importing ##
 
 An existing Interface FC Policy can be [imported][docs-import] into this resource via its Dn, via the following command:
-[docs-import]: https://www.terraform.io/docs/import/index.html
+[docs-import]: <https://www.terraform.io/docs/import/index.html>
 
-
-```
+```bash
 terraform import aci_interface_fc_policy.example <Dn>
 ```

--- a/website/docs/r/l2_interface_policy.html.markdown
+++ b/website/docs/r/l2_interface_policy.html.markdown
@@ -7,22 +7,25 @@ description: |-
 ---
 
 # aci_l2_interface_policy #
+
 Manages ACI L2 Interface Policy
 
 ## Example Usage ##
 
 ```hcl
-	resource "aci_l2_interface_policy" "fool2_interface_policy" {
-		description = "%s"
-		name        = "demo_l2_pol"
-		annotation  = "tag_l2_pol"
-		name_alias  = "alias_l2_pol"
-		qinq        = "disabled"
-		vepa        = "disabled"
-		vlan_scope  = "global"
-	}
+resource "aci_l2_interface_policy" "example" {
+  description = "example description"
+  name        = "demo_l2_pol"
+  annotation  = "tag_l2_pol"
+  name_alias  = "alias_l2_pol"
+  qinq        = "disabled"
+  vepa        = "disabled"
+  vlan_scope  = "global"
+}
 ```
+
 ## Argument Reference ##
+
 * `name` - (Required) name of Object l2_interface_policy.
 * `annotation` - (Optional) annotation for object l2_interface_policy.
 * `name_alias` - (Optional) name_alias for object l2_interface_policy.
@@ -30,9 +33,7 @@ Manages ACI L2 Interface Policy
 * `vepa` - (Optional) Determines if Virtual Ethernet Port Aggregator is disabled or enabled. Allowed values are "disabled" and "enabled". Default is "disabled".
 * `vlan_scope` - (Optional) The scope of the VLAN. Allowed values are "global" and "portlocal". Default is "global".
 
-
-
-## Attribute Reference
+## Attribute Reference ##
 
 The only attribute that this resource exports is the `id`, which is set to the
 Dn of the L2 Interface Policy.
@@ -40,9 +41,8 @@ Dn of the L2 Interface Policy.
 ## Importing ##
 
 An existing L2 Interface Policy can be [imported][docs-import] into this resource via its Dn, via the following command:
-[docs-import]: https://www.terraform.io/docs/import/index.html
+[docs-import]: <https://www.terraform.io/docs/import/index.html>
 
-
-```
+```bash
 terraform import aci_l2_interface_policy.example <Dn>
 ```

--- a/website/docs/r/lacp_policy.html.markdown
+++ b/website/docs/r/lacp_policy.html.markdown
@@ -7,27 +7,28 @@ description: |-
 ---
 
 # aci_lacp_policy #
+
 Manages ACI LACP Policy
 
 ## Example Usage ##
 
 ```hcl
 
-	resource "aci_lacp_policy" "foolacp_policy" {
-		description = "%s"
-		name        = "demo_lacp_pol"
-		annotation  = "tag_lacp"
-		ctrl        = ["susp-individual", "load-defer", "graceful-conv"]
-		max_links   = "16"
-		min_links   = "1"
-		mode        = "%s"
-		name_alias  = "alias_lacp"
-	}
+resource "aci_lacp_policy" "example" {
+  description = "example_description"
+  name        = "demo_lacp_pol"
+  annotation  = "tag_lacp"
+  ctrl        = ["susp-individual", "load-defer", "graceful-conv"]
+  max_links   = "16"
+  min_links   = "1"
+  mode        = "off"
+  name_alias  = "alias_lacp"
+}
 
 ```
 
-
 ## Argument Reference ##
+
 * `name` - (Required) name of Object lacp_policy.
 * `annotation` - (Optional) annotation for object lacp_policy.
 * `ctrl` - (Optional) List of LAG control properties. Allowed values are "symmetric-hash", "susp-individual", "graceful-conv", "load-defer" and "fast-sel-hot-stdby".
@@ -36,9 +37,7 @@ Manages ACI LACP Policy
 * `mode` - (Optional) policy mode. Allowed values are "off", "active", "passive", "mac-pin" and "mac-pin-nicload". Default is "off".
 * `name_alias` - (Optional) name_alias for object lacp_policy.
 
-
-
-## Attribute Reference
+## Attribute Reference ##
 
 The only attribute that this resource exports is the `id`, which is set to the
 Dn of the LACP Policy.
@@ -46,9 +45,8 @@ Dn of the LACP Policy.
 ## Importing ##
 
 An existing LACP Policy can be [imported][docs-import] into this resource via its Dn, via the following command:
-[docs-import]: https://www.terraform.io/docs/import/index.html
+[docs-import]: <https://www.terraform.io/docs/import/index.html>
 
-
-```
+```bash
 terraform import aci_lacp_policy.example <Dn>
 ```

--- a/website/docs/r/lldp_interface_policy.html.markdown
+++ b/website/docs/r/lldp_interface_policy.html.markdown
@@ -7,30 +7,31 @@ description: |-
 ---
 
 # aci_lldp_interface_policy #
+
 Manages ACI LLDP Interface Policy
 
 ## Example Usage ##
 
 ```hcl
-	resource "aci_lldp_interface_policy" "foolldp_interface_policy" {
-		description = "%s"
-		name        = "demo_lldp_pol"
-		admin_rx_st = "%s"
-		admin_tx_st = "enabled"
-		annotation  = "tag_lldp"
-		name_alias  = "alias_lldp"
-	} 
+resource "aci_lldp_interface_policy" "example" {
+  description = "example description"
+  name        = "demo_lldp_pol"
+  admin_rx_st = "enabled"
+  admin_tx_st = "enabled"
+  annotation  = "tag_lldp"
+  name_alias  = "alias_lldp"
+} 
 ```
+
 ## Argument Reference ##
+
 * `name` - (Required) name of Object lldp_interface_policy.
 * `admin_rx_st` - (Optional) admin receive state. Allowed values are "enabled" and "disabled". Default value is "enabled".
 * `admin_tx_st` - (Optional) admin transmit state. Allowed values are "enabled" and "disabled". Default value is "enabled".
 * `annotation` - (Optional) annotation for object lldp_interface_policy.
 * `name_alias` - (Optional) name_alias for object lldp_interface_policy.
 
-
-
-## Attribute Reference
+## Attribute Reference ##
 
 The only attribute that this resource exports is the `id`, which is set to the
 Dn of the LLDP Interface Policy.
@@ -38,9 +39,8 @@ Dn of the LLDP Interface Policy.
 ## Importing ##
 
 An existing LLDP Interface Policy can be [imported][docs-import] into this resource via its Dn, via the following command:
-[docs-import]: https://www.terraform.io/docs/import/index.html
+[docs-import]: <https://www.terraform.io/docs/import/index.html>
 
-
-```
+```bash
 terraform import aci_lldp_interface_policy.example <Dn>
 ```

--- a/website/docs/r/miscabling_protocol_interface_policy.html.markdown
+++ b/website/docs/r/miscabling_protocol_interface_policy.html.markdown
@@ -7,28 +7,29 @@ description: |-
 ---
 
 # aci_miscabling_protocol_interface_policy #
+
 Manages ACI Mis-cabling Protocol Interface Policy
 
 ## Example Usage ##
 
 ```hcl
-	resource "aci_miscabling_protocol_interface_policy" "foomiscabling_protocol_interface_policy" {
-		description = "%s"
-		name        = "demo_mcpol"
-		admin_st    = "%s"
-		annotation  = "tag_mcpol"
-		name_alias  = "alias_mcpol"
-	}
+resource "aci_miscabling_protocol_interface_policy" "example" {
+  description = "example description"
+  name        = "demo_mcpol"
+  admin_st    = "enabled"
+  annotation  = "tag_mcpol"
+  name_alias  = "alias_mcpol"
+}
 ```
+
 ## Argument Reference ##
+
 * `name` - (Required) name of Object miscabling_protocol_interface_policy.
 * `admin_st` - (Optional) administrative state of the object or policy. Allowed values are "enabled" and "disabled". Default is "enabled".
 * `annotation` - (Optional) annotation for object miscabling_protocol_interface_policy.
 * `name_alias` - (Optional) name_alias for object miscabling_protocol_interface_policy.
 
-
-
-## Attribute Reference
+## Attribute Reference ##
 
 The only attribute that this resource exports is the `id`, which is set to the
 Dn of the Mis-cabling Protocol Interface Policy.
@@ -36,9 +37,8 @@ Dn of the Mis-cabling Protocol Interface Policy.
 ## Importing ##
 
 An existing Mis-cabling Protocol Interface Policy can be [imported][docs-import] into this resource via its Dn, via the following command:
-[docs-import]: https://www.terraform.io/docs/import/index.html
+[docs-import]: <https://www.terraform.io/docs/import/index.html>
 
-
-```
+```bash
 terraform import aci_miscabling_protocol_interface_policy.example <Dn>
 ```

--- a/website/docs/r/physical_domain.html.markdown
+++ b/website/docs/r/physical_domain.html.markdown
@@ -7,35 +7,31 @@ description: |-
 ---
 
 # aci_physical_domain #
+
 Manages ACI Physical Domain
 
 ## Example Usage ##
 
 ```hcl
 resource "aci_physical_domain" "example" {
-
-
-  name  = "example"
-  annotation  = "example"
-  name_alias  = "example"
+  name        = "example"
+  annotation  = "tag_domain"
+  name_alias  = "alias_domain"
 }
 ```
+
 ## Argument Reference ##
+
 * `name` - (Required) name of Object physical_domain.
 * `annotation` - (Optional) annotation for object physical_domain.
 * `name_alias` - (Optional) name_alias for object physical_domain.
 
 * `relation_infra_rs_vlan_ns` - (Optional) Relation to class fvnsVlanInstP. Cardinality - N_TO_ONE. Type - String.
-                
 * `relation_infra_rs_vlan_ns_def` - (Optional) Relation to class fvnsAInstP. Cardinality - N_TO_ONE. Type - String.
-                
 * `relation_infra_rs_vip_addr_ns` - (Optional) Relation to class fvnsAddrInst. Cardinality - N_TO_ONE. Type - String.
-                
 * `relation_infra_rs_dom_vxlan_ns_def` - (Optional) Relation to class fvnsAInstP. Cardinality - N_TO_ONE. Type - String.
-                
 
-
-## Attribute Reference
+## Attribute Reference ##
 
 The only attribute that this resource exports is the `id`, which is set to the
 Dn of the Physical Domain.
@@ -43,9 +39,8 @@ Dn of the Physical Domain.
 ## Importing ##
 
 An existing Physical Domain can be [imported][docs-import] into this resource via its Dn, via the following command:
-[docs-import]: https://www.terraform.io/docs/import/index.html
+[docs-import]: <https://www.terraform.io/docs/import/index.html>
 
-
-```
+```bash
 terraform import aci_physical_domain.example <Dn>
 ```

--- a/website/docs/r/ranges.html.markdown
+++ b/website/docs/r/ranges.html.markdown
@@ -7,22 +7,21 @@ description: |-
 ---
 
 # aci_ranges #
+
 Manages ACI Ranges
 
 ## Example Usage ##
 
 ```hcl
-
 resource "aci_ranges" "example" {
-  vlan_pool_dn  = "${aci_vlan_pool.example.id}"
-  from  = "example"
-  to  = "example"
-  alloc_mode  = "example"
-  annotation  = "example"
-  name_alias  = "example"
-  role  = "example"
+  vlan_pool_dn  = aci_vlan_pool.example.id
+  from          = "example"
+  to            = "example"
+  alloc_mode    = "example"
+  annotation    = "example"
+  name_alias    = "example"
+  role          = "external"
 }
-
 ```
 
 ## Argument Reference ##
@@ -30,16 +29,12 @@ resource "aci_ranges" "example" {
 * `vlan_pool_dn` - (Required) Distinguished name of parent VLANPool object.
 * `from` - (Required) _from of Object ranges.
 * `to` - (Required) to of Object ranges.
-* `alloc_mode` - (Optional) alloc_mode for object ranges.
-Allowed values: "dynamic", "static", "inherit"
+* `alloc_mode` - (Optional) alloc_mode for object ranges.  Allowed values: "dynamic", "static", "inherit".
 * `annotation` - (Optional) annotation for object ranges.
 * `name_alias` - (Optional) name_alias for object ranges.
-* `role` - (Optional) system role type.
-Allowed values: "external", "internal"
+* `role` - (Optional) system role type.  Allowed values: "external", "internal".  Default is "external".
 
-
-
-## Attribute Reference
+## Attribute Reference ##
 
 The only attribute that this resource exports is the `id`, which is set to the
 Dn of the Ranges.
@@ -47,9 +42,8 @@ Dn of the Ranges.
 ## Importing ##
 
 An existing Ranges can be [imported][docs-import] into this resource via its Dn, via the following command:
-[docs-import]: https://www.terraform.io/docs/import/index.html
+[docs-import]: <https://www.terraform.io/docs/import/index.html>
 
-
-```
+```bash
 terraform import aci_ranges.example <Dn>
 ```

--- a/website/docs/r/rest.html.markdown
+++ b/website/docs/r/rest.html.markdown
@@ -7,7 +7,8 @@ description: |-
 ---
 
 # aci_rest #
-Manages ACI Model Objects via REST API calls. Any Model Object that is not supported by provider can be created/managed using this resource. 
+
+Manages ACI Model Objects via REST API calls. Any Model Object that is not supported by provider can be created/managed using this resource.
 
 ## Example Usage ##
 
@@ -20,7 +21,6 @@ resource "aci_tenant" "tenant_for_rest_example" {
 resource "aci_rest" "rest_l3_ext_out" {
   path       = "/api/node/mo/${aci_tenant.tenant_for_rest_example.id}/out-test_ext.json"
   class_name = "l3extOut"
-
   content = {
     "name" = "test_ext"
   }
@@ -52,15 +52,16 @@ resource "aci_rest" "madebyrest_yaml" {
 ```
 
 ## Argument Reference ##
+
 * `path` - (Required) ACI path where object should be created. Starting with api/node/mo/{parent-dn}(if applicable)/{rn of object}.json  
 * `class_name` - (Optional) Which class object is being created. (Make sure there is no colon in the classname )
 * `content` - (Optional) Map of key-value pairs those needed to be passed to the Model object as parameters. Make sure the key name matches the name with the object parameter in ACI.
 * `payload` - (Optional) Freestyle JSON or YAML payload which can directly be passed to the REST endpoint added in path. Either of content or payload is required.
-* `dn` - (Optional) Distinguished name of object being managed. 
+* `dn` - (Optional) Distinguished name of object being managed.
 
-<strong>NOTE:</strong> We don't set the Status field explicitly, as it creates an issue with the relation objects. If you have requirement to pass the status field, pass it in the content. 
+**NOTE:** We don't set the Status field explicitly, as it creates an issue with the relation objects. If you have requirement to pass the status field, pass it in the content.
 
-## Attribute Reference
+## Attribute Reference ##
 
 The only attribute that this resource exports is the `id`, which is set to the
 Dn of the object created by it.

--- a/website/docs/r/span_source_group.html.markdown
+++ b/website/docs/r/span_source_group.html.markdown
@@ -7,34 +7,32 @@ description: |-
 ---
 
 # aci_span_source_group #
+
 Manages ACI SPAN Source Group
 
 ## Example Usage ##
 
 ```hcl
 resource "aci_span_source_group" "example" {
-
-  tenant_dn  = "${aci_tenant.example.id}"
-
-  name  = "example"
-  admin_st  = "example"
-  annotation  = "example"
-  name_alias  = "example"
+  tenant_dn  = aci_tenant.example.id
+  name        = "example"
+  admin_st    = "example"
+  annotation  = "tag_span"
+  name_alias  = "alias_span"
 }
 ```
+
 ## Argument Reference ##
+
 * `tenant_dn` - (Required) Distinguished name of parent Tenant object.
 * `name` - (Required) name of Object span_source_group.
 * `admin_st` - (Optional) administrative state of the object or policy.
 Allowed values: "enabled", "disabled"
-* `annotation` - (Optional) 
-* `name_alias` - (Optional) 
-
+* `annotation` - (Optional)
+* `name_alias` - (Optional)
 * `relation_span_rs_src_grp_to_filter_grp` - (Optional) Relation to class spanFilterGrp. Cardinality - N_TO_ONE. Type - String.
-                
 
-
-## Attribute Reference
+## Attribute Reference ##
 
 The only attribute that this resource exports is the `id`, which is set to the
 Dn of the SPAN Source Group.
@@ -42,9 +40,8 @@ Dn of the SPAN Source Group.
 ## Importing ##
 
 An existing SPAN Source Group can be [imported][docs-import] into this resource via its Dn, via the following command:
-[docs-import]: https://www.terraform.io/docs/import/index.html
+[docs-import]: <https://www.terraform.io/docs/import/index.html>
 
-
-```
+```bash
 terraform import aci_span_source_group.example <Dn>
 ```

--- a/website/docs/r/span_sourcedestination_group_match_label.html.markdown
+++ b/website/docs/r/span_sourcedestination_group_match_label.html.markdown
@@ -7,32 +7,31 @@ description: |-
 ---
 
 # aci_span_sourcedestination_group_match_label #
+
 Manages ACI SPAN Source-destination Group Match Label
 
 ## Example Usage ##
 
 ```hcl
 resource "aci_span_sourcedestination_group_match_label" "example" {
-
-  span_source_group_dn  = "${aci_span_source_group.example.id}"
-
-  name  = "example"
-  annotation  = "example"
-  name_alias  = "example"
-  tag  = "example"
+  span_source_group_dn  = aci_span_source_group.example.id
+  name                  = "example"
+  annotation            = "tag_label"
+  name_alias            = "alias_label"
+  tag                   = "label_color"
 }
 ```
+
 ## Argument Reference ##
+
 * `span_source_group_dn` - (Required) Distinguished name of parent SPANSourceGroup object.
 * `name` - (Required) name of Object span_sourcedestination_group_match_label.
-* `annotation` - (Optional) 
-* `name_alias` - (Optional) 
+* `annotation` - (Optional)
+* `name_alias` - (Optional)
 * `tag` - (Optional) label color.
-Allowed values: "black", "navy", "dark-blue", "medium-blue", "blue", "dark-green", "green", "teal", "dark-cyan", "deep-sky-blue", "dark-turquoise", "medium-spring-green", "lime", "spring-green", "aqua", "cyan", "midnight-blue", "dodger-blue", "light-sea-green", "forest-green", "sea-green", "dark-slate-gray", "lime-green", "medium-sea-green", "turquoise", "royal-blue", "steel-blue", "dark-slate-blue", "medium-turquoise", "indigo", "dark-olive-green", "cadet-blue", "cornflower-blue", "medium-aquamarine", "dim-gray", "slate-blue", "olive-drab", "slate-gray", "light-slate-gray", "medium-slate-blue", "lawn-green", "chartreuse", "aquamarine", "maroon", "purple", "olive", "gray", "sky-blue", "light-sky-blue", "blue-violet", "dark-red", "dark-magenta", "saddle-brown", "dark-sea-green", "light-green", "medium-purple", "dark-violet", "pale-green", "dark-orchid", "yellow-green", "sienna", "brown", "dark-gray", "light-blue", "green-yellow", "pale-turquoise", "light-steel-blue", "powder-blue", "fire-brick", "dark-goldenrod", "medium-orchid", "rosy-brown", "dark-khaki", "silver", "medium-violet-red", "indian-red", "peru", "chocolate", "tan", "light-gray", "thistle", "orchid", "goldenrod", "pale-violet-red", "crimson", "gainsboro", "plum", "burlywood", "light-cyan", "lavender", "dark-salmon", "violet", "pale-goldenrod", "light-coral", "khaki", "alice-blue", "honeydew", "azure", "sandy-brown", "wheat", "beige", "white-smoke", "mint-cream", "ghost-white", "salmon", "antique-white",	"linen", "light-goldenrod-yellow", "old-lace", "red", "fuchsia", "magenta", "deep-pink", "orange-red", "tomato", "hot-pink", "coral", "dark-orange", "light-salmon", "orange", "light-pink", "pink", "gold", "peachpuff", "navajo-white", "moccasin", "bisque", "misty-rose", "blanched-almond", "papaya-whip", "lavender-blush",	"seashell", "cornsilk", "lemon-chiffon", "floral-white", "snow", "yellow", "light-yellow", "ivory", "white"
+Allowed values: "black", "navy", "dark-blue", "medium-blue", "blue", "dark-green", "green", "teal", "dark-cyan", "deep-sky-blue", "dark-turquoise", "medium-spring-green", "lime", "spring-green", "aqua", "cyan", "midnight-blue", "dodger-blue", "light-sea-green", "forest-green", "sea-green", "dark-slate-gray", "lime-green", "medium-sea-green", "turquoise", "royal-blue", "steel-blue", "dark-slate-blue", "medium-turquoise", "indigo", "dark-olive-green", "cadet-blue", "cornflower-blue", "medium-aquamarine", "dim-gray", "slate-blue", "olive-drab", "slate-gray", "light-slate-gray", "medium-slate-blue", "lawn-green", "chartreuse", "aquamarine", "maroon", "purple", "olive", "gray", "sky-blue", "light-sky-blue", "blue-violet", "dark-red", "dark-magenta", "saddle-brown", "dark-sea-green", "light-green", "medium-purple", "dark-violet", "pale-green", "dark-orchid", "yellow-green", "sienna", "brown", "dark-gray", "light-blue", "green-yellow", "pale-turquoise", "light-steel-blue", "powder-blue", "fire-brick", "dark-goldenrod", "medium-orchid", "rosy-brown", "dark-khaki", "silver", "medium-violet-red", "indian-red", "peru", "chocolate", "tan", "light-gray", "thistle", "orchid", "goldenrod", "pale-violet-red", "crimson", "gainsboro", "plum", "burlywood", "light-cyan", "lavender", "dark-salmon", "violet", "pale-goldenrod", "light-coral", "khaki", "alice-blue", "honeydew", "azure", "sandy-brown", "wheat", "beige", "white-smoke", "mint-cream", "ghost-white", "salmon", "antique-white", "linen", "light-goldenrod-yellow", "old-lace", "red", "fuchsia", "magenta", "deep-pink", "orange-red", "tomato", "hot-pink", "coral", "dark-orange", "light-salmon", "orange", "light-pink", "pink", "gold", "peachpuff", "navajo-white", "moccasin", "bisque", "misty-rose", "blanched-almond", "papaya-whip", "lavender-blush", "seashell", "cornsilk", "lemon-chiffon", "floral-white", "snow", "yellow", "light-yellow", "ivory", "white"
 
-
-
-## Attribute Reference
+## Attribute Reference ##
 
 The only attribute that this resource exports is the `id`, which is set to the
 Dn of the SPAN Source-destination Group Match Label.
@@ -40,9 +39,8 @@ Dn of the SPAN Source-destination Group Match Label.
 ## Importing ##
 
 An existing SPAN Source-destination Group Match Label can be [imported][docs-import] into this resource via its Dn, via the following command:
-[docs-import]: https://www.terraform.io/docs/import/index.html
+[docs-import]: <https://www.terraform.io/docs/import/index.html>
 
-
-```
+```bash
 terraform import aci_span_sourcedestination_group_match_label.example <Dn>
 ```

--- a/website/docs/r/vlan_pool.html.markdown
+++ b/website/docs/r/vlan_pool.html.markdown
@@ -7,6 +7,7 @@ description: |-
 ---
 
 # aci_vlan_pool #
+
 Manages ACI VLAN Pool
 
 ## Example Usage ##
@@ -22,16 +23,15 @@ resource "aci_vlan_pool" "example" {
   name_alias  = "example"
 }
 ```
+
 ## Argument Reference ##
+
 * `name` - (Required) name of Object vlan_pool.
-* `alloc_mode` - (Required) allocation mode.
-Allowed values: "dynamic", "static"
+* `alloc_mode` - (Required) allocation mode.  Allowed values: "dynamic", "static"
 * `annotation` - (Optional) annotation for object vlan_pool.
 * `name_alias` - (Optional) name_alias for object vlan_pool.
 
-
-
-## Attribute Reference
+## Attribute Reference ##
 
 The only attribute that this resource exports is the `id`, which is set to the
 Dn of the VLAN Pool.
@@ -39,9 +39,8 @@ Dn of the VLAN Pool.
 ## Importing ##
 
 An existing VLAN Pool can be [imported][docs-import] into this resource via its Dn, via the following command:
-[docs-import]: https://www.terraform.io/docs/import/index.html
+[docs-import]: <https://www.terraform.io/docs/import/index.html>
 
-
-```
+```bash
 terraform import aci_vlan_pool.example <Dn>
 ```

--- a/website/docs/r/vpc_explicit_protection_group.html.markdown
+++ b/website/docs/r/vpc_explicit_protection_group.html.markdown
@@ -7,32 +7,32 @@ description: |-
 ---
 
 # aci_vpc_explicit_protection_group #
+
 Manages ACI VPC Explicit Protection Group
 
 ## Example Usage ##
 
 ```hcl
 resource "aci_vpc_explicit_protection_group" "example" {
-
-
-  name  = "example"
-  annotation  = "example"
-  switch1 = "switch1 id"
-  switch2 = "switch2 id"
-  vpc_domain_policy = "test"
-  vpc_explicit_protection_group_id  = "example"
+  name                              = "example"
+  annotation                        = "tag_vpc"
+  switch1                           = "switch1_id"
+  switch2                           = "switch2_id"
+  vpc_domain_policy                 = "test"
+  vpc_explicit_protection_group_id  = "1"
 }
 ```
+
 ## Argument Reference ##
+
 * `name` - (Required) name of Object vpc_explicit_protection_group.
-* `switch1` - (Required) Id of switch 1 to attach.
-* `switch2` - (Required) Id of switch 2 to attach.
+* `switch1` - (Required) Node Id of switch 1 to attach.
+* `switch2` - (Required) Node Id of switch 2 to attach.
 * `annotation` - (Optional) annotation for object vpc_explicit_protection_group.
-* `vpc_explicit_protection_group_id` - (Optional) explicit protection group ID
-* `vpc_domain_policy` - (Optional) VPC domain policy name.              
+* `vpc_domain_policy` - (Optional) VPC domain policy name.
+* `vpc_explicit_protection_group_id` - (Optional) explicit protection group ID.  Between 1-1000
 
-
-## Attribute Reference
+## Attribute Reference ##
 
 The only attribute that this resource exports is the `id`, which is set to the
 Dn of the VPC Explicit Protection Group.
@@ -40,9 +40,8 @@ Dn of the VPC Explicit Protection Group.
 ## Importing ##
 
 An existing VPC Explicit Protection Group can be [imported][docs-import] into this resource via its Dn, via the following command:
-[docs-import]: https://www.terraform.io/docs/import/index.html
+[docs-import]: <https://www.terraform.io/docs/import/index.html>
 
-
-```
+```bash
 terraform import aci_vpc_explicit_protection_group.example <Dn>
 ```

--- a/website/docs/r/vrf.html.markdown
+++ b/website/docs/r/vrf.html.markdown
@@ -7,13 +7,14 @@ description: |-
 ---
 
 # aci_vrf #
+
 Manages ACI VRF
 
 ## Example Usage ##
 
 ```hcl
 resource "aci_vrf" "foovrf" {
-  tenant_dn   		       = "${aci_tenant.tenant_for_vrf.id}"
+  tenant_dn              = aci_tenant.tenant_for_vrf.id
   name                   = "demo_vrf"
   annotation             = "tag_vrf"
   bd_enforced_enable     = "no"
@@ -24,40 +25,31 @@ resource "aci_vrf" "foovrf" {
   pc_enf_pref            = "unenforced"
 }
 ```
+
 ## Argument Reference ##
+
 * `tenant_dn` - (Required) Distinguished name of parent Tenant object.
 * `name` - (Required) name of Object vrf.
 * `annotation` - (Optional) annotation tags for object vrf.
 * `bd_enforced_enable` - (Optional) Flag to enable/disable bd_enforced for VRF.Allowed values are "yes" and "no". Default is "no".  
-* `ip_data_plane_learning` - (Optional) Flag to enable/disable ip-data-plane learning for VRF. Allowed values are "enabled" and "disabled". Default is "enabled".  
+* `ip_data_plane_learning` - (Optional) Flag to enable/disable ip-data-plane learning for VRF. Allowed values are "enabled" and disabled". Default is "enabled".  
 * `knw_mcast_act` - (Optional) specifies if known multicast traffic is forwarded or not. Allowed values are "permit" and "deny". Default is "permit".
 * `name_alias` - (Optional) name_alias for object vrf.
 * `pc_enf_dir` - (Optional) Policy Control Enforcement Direction. It is used for defining policy enforcement direction for the traffic coming to or from an L3Out. Egress and Ingress directions are wrt L3Out. Default will be Ingress. But on the existing L3Outs during upgrade it will get set to Egress so that right after upgrade behavior doesn't change for them. This also means that there is no special upgrade sequence needed for upgrading to the release introducing this feature. After upgrade user would have to change the property value to Ingress. Once changed, system will reprogram the rules and prefix entry. Rules will get removed from the egress leaf and will get installed on the ingress leaf. Actrl prefix entry, if not already, will get installed on the ingress leaf. This feature will be ignored for the following cases: 1. Golf: Gets applied at Ingress by design. 2. Transit Rules get applied at Ingress by design. 4. vzAny 5. Taboo. Allowed values are "egress" and "ingress". Default is "ingress".
 * `pc_enf_pref` - (Optional) Determines if the fabric should enforce contract policies to allow routing and packet forwarding. Allowed values are "enforced" and "unenforced". Default is "enforced".
 
 * `relation_fv_rs_ospf_ctx_pol` - (Optional) Relation to class ospfCtxPol. Cardinality - N_TO_ONE. Type - String.
-                
 * `relation_fv_rs_vrf_validation_pol` - (Optional) Relation to class l3extVrfValidationPol. Cardinality - N_TO_ONE. Type - String.
-                
-* `relation_fv_rs_ctx_mcast_to` - (Optional) Relation to class vzFilter. Cardinality - N_TO_M. Type - Set of String.
-                
-* `relation_fv_rs_ctx_to_eigrp_ctx_af_pol` - (Optional) Relation to class eigrpCtxAfPol. Cardinality - N_TO_M. Type - Set of Map.
-                
-* `relation_fv_rs_ctx_to_ospf_ctx_pol` - (Optional) Relation to class ospfCtxPol. Cardinality - N_TO_M. Type - Set of Map.
-                
+* `relation_fv_rs_ctx_mcast_to` - (Optional) Relation to class vzFilter. Cardinality - N_TO_M. Type - [Set of String].
+* `relation_fv_rs_ctx_to_eigrp_ctx_af_pol` - (Optional) Relation to class eigrpCtxAfPol. Cardinality - N_TO_M. Type - [Set of Map].
+* `relation_fv_rs_ctx_to_ospf_ctx_pol` - (Optional) Relation to class ospfCtxPol. Cardinality - N_TO_M. Type - [Set of Map].
 * `relation_fv_rs_ctx_to_ep_ret` - (Optional) Relation to class fvEpRetPol. Cardinality - N_TO_ONE. Type - String.
-                
 * `relation_fv_rs_bgp_ctx_pol` - (Optional) Relation to class bgpCtxPol. Cardinality - N_TO_ONE. Type - String.
-                
 * `relation_fv_rs_ctx_mon_pol` - (Optional) Relation to class monEPGPol. Cardinality - N_TO_ONE. Type - String.
-                
 * `relation_fv_rs_ctx_to_ext_route_tag_pol` - (Optional) Relation to class l3extRouteTagPol. Cardinality - N_TO_ONE. Type - String.
-                
-* `relation_fv_rs_ctx_to_bgp_ctx_af_pol` - (Optional) Relation to class bgpCtxAfPol. Cardinality - N_TO_M. Type - Set of Map.
-                
+* `relation_fv_rs_ctx_to_bgp_ctx_af_pol` - (Optional) Relation to class bgpCtxAfPol. Cardinality - N_TO_M. Type - [Set of Map].
 
-
-## Attribute Reference
+## Attribute Reference ##
 
 The only attribute that this resource exports is the `id`, which is set to the
 Dn of the VRF.
@@ -65,9 +57,8 @@ Dn of the VRF.
 ## Importing ##
 
 An existing VRF can be [imported][docs-import] into this resource via its Dn, via the following command:
-[docs-import]: https://www.terraform.io/docs/import/index.html
+[docs-import]: <https://www.terraform.io/docs/import/index.html>
 
-
-```
+```bash
 terraform import aci_vrf.example <Dn>
 ```


### PR DESCRIPTION
Recreating PR from Tyson Scott as I closed it by mistake:
> In aci_lacp_policy documentation I changed the range for max and min_links to 1-16
> in aci_interface_fc_policy documentation I changed the bb_credit range to 1-64
> 
> On the rest of the documentation I did general markup correction for acceptable formatting
> 
> I am happy to go through and fix the rest of the documentation as well but I wanted to first check this in and if it is agreeable then I will modify the rest of the documentation
> 
> Examples of changes
> if the resource was tabbed in I removed the tabs
> on the _dn references in the resources I fixed I removed the "${}" to update it to the new Terraform standards
> Updated several descriptions and name_alias/annotations to make it more relevant to the example.
> 
> I will do the rest of the documentation if you agree with the changes I made.
> 
> Regards,
> 
> Tyson Scott