### PR TITLE
updated documentation of aci_cloud_aws_provider with region attribute…

### DIFF
--- a/website/docs/d/cloud_aws_provider.html.markdown
+++ b/website/docs/d/cloud_aws_provider.html.markdown
@@ -33,5 +33,5 @@ data "aci_cloud_aws_provider" "aws_prov" {
 * `is_trusted` - (Optional) is_trusted for object cloud_aws_provider.
 * `name_alias` - (Optional) name_alias for object cloud_aws_provider.
 * `provider_id` - (Optional) provider_id for object cloud_aws_provider.
-* `region` - (Optional) region for object cloud_aws_provider.
+* `region` - (Optional) region for object cloud_aws_provider. \[Supported only in Cloud APIC 4.2(x) or earlier\]
 * `secret_access_key` - (Optional) secret_access_key for object cloud_aws_provider.

--- a/website/docs/r/cloud_aws_provider.html.markdown
+++ b/website/docs/r/cloud_aws_provider.html.markdown
@@ -35,7 +35,7 @@ Allowed values: "no", "yes"
 Allowed values: "no", "yes"
 * `name_alias` - (Optional) name_alias for object cloud_aws_provider.
 * `provider_id` - (Optional) provider_id for object cloud_aws_provider.
-* `region` - (Optional) which AWS region to manage.
+* `region` - (Optional) which AWS region to manage. \[Supported only in Cloud APIC 4.2(x) or earlier\]
 * `secret_access_key` - (Optional) secret_access_key for the AWS account provided in the account_id field.
 
 

--- a/website/docs/r/cloud_aws_provider.html.markdown
+++ b/website/docs/r/cloud_aws_provider.html.markdown
@@ -35,7 +35,7 @@ Allowed values: "no", "yes"
 Allowed values: "no", "yes"
 * `name_alias` - (Optional) name_alias for object cloud_aws_provider.
 * `provider_id` - (Optional) provider_id for object cloud_aws_provider.
-* `region` - (Optional) which AWS region to manage. \[Supported only in Cloud APIC 4.2(x) or earlier\]
+* `region` - (Optional) region for object cloud_aws_provider. \[Supported only in Cloud APIC 4.2(x) or earlier\]
 * `secret_access_key` - (Optional) secret_access_key for the AWS account provided in the account_id field.
 
 


### PR DESCRIPTION
The "region" attribute is supported only in cloud APIC v4.2(x) or earlier. Added comment in documentation to acknowledge the same to user.
[GitHub #184](https://github.com/CiscoDevNet/terraform-provider-aci/issues/184)