### PR TITLE
[*aci_filter_entry, aci_application_epg]Fixes unspecified/none being shown as empty strings on tf state file

### DIFF
--- a/aci/resource_aci_fvaepg.go
+++ b/aci/resource_aci_fvaepg.go
@@ -124,6 +124,9 @@ func resourceAciApplicationEPG() *schema.Resource {
 				Computed: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"unspecified",
+					"level6",
+					"level5",
+					"level4",
 					"level3",
 					"level2",
 					"level1",
@@ -255,6 +258,11 @@ func setApplicationEPGAttributes(fvAEPg *models.ApplicationEPG, d *schema.Resour
 	d.Set("exception_tag", fvAEPgMap["exceptionTag"])
 	d.Set("flood_on_encap", fvAEPgMap["floodOnEncap"])
 	d.Set("fwd_ctrl", fvAEPgMap["fwdCtrl"])
+	if fvAEPgMap["fwdCtrl"] == "" {
+		d.Set("fwd_ctrl", "none")
+	} else {
+		d.Set("fwd_ctrl", fvAEPgMap["fwdCtrl"])
+	}
 	d.Set("has_mcast_source", fvAEPgMap["hasMcastSource"])
 	d.Set("is_attr_based_epg", fvAEPgMap["isAttrBasedEPg"])
 	d.Set("match_t", fvAEPgMap["matchT"])

--- a/website/docs/r/application_epg.html.markdown
+++ b/website/docs/r/application_epg.html.markdown
@@ -43,7 +43,7 @@ Manages ACI Application EPG
 * `name_alias` - (Optional) name_alias for object application_epg.
 * `pc_enf_pref` - (Optional) The preferred policy control. Allowed values are "unenforced" and "enforced". Default is "unenforced".
 * `pref_gr_memb` - (Optional) Represents parameter used to determine if EPg is part of a group that does not a contract for communication. Allowed values are "exclude" and "include". Default is "exclude".
-* `prio` - (Optional) qos priority class id. Allowed values are "unspecified", "level1", "level2", "level3", "level4", "level5" and "level6". Default is "unspecified.
+* `prio` - (Optional) qos priority class id. Allowed values are "unspecified", "level1", "level2", "level3", "level4", "level5" and "level6". Default is "unspecified".
 * `shutdown` - (Optional) shutdown for object application_epg. Allowed values are "yes" and "no". Default is "no".
 
 * `relation_fv_rs_bd` - (Required) Relation to Bridge domain associated with EPG (Point to class fvBD). Cardinality - N_TO_ONE. Type - String.

--- a/website/docs/r/filter_entry.html.markdown
+++ b/website/docs/r/filter_entry.html.markdown
@@ -30,7 +30,7 @@ Manages ACI Filter Entry
 		s_from_port   = "0"
 		s_to_port     = "0"
 		stateful      = "no"
-		tcp_rules     = "ack"
+		tcp_rules     = ["ack","rst"]
 	}
 ```
 ## Argument Reference ##
@@ -54,7 +54,7 @@ Allowed values: "unspecified", "ftpData", "smtp", "dns", "http","pop3", "https",
 * `s_to_port` - (Optional) Source To Port. Accepted values are any valid TCP/UDP port range. Default is "unspecified".
 Allowed values: "unspecified", "ftpData", "smtp", "dns", "http","pop3", "https", "rtsp"
 * `stateful` - (Optional) Determines if entry is stateful or not. Allowed values are "yes" and "no". Default is "no".
-* `tcp_rules` - (Optional) TCP Session Rules. Allowed values are "unspecified", "est", "syn", "ack", "fin" and "rst". Default is "unspecified".
+* `tcp_rules` - (Optional) TCP Rules. TCP Session Rules Allowed values are "ack", "est", "fin", "rst", "syn", "unspecified", and default value is "unspecified". Type: List.
 
 
 


### PR DESCRIPTION
1. Changed data type of tcp_rules from String to List because the attribute can take more than one value
2. Updated the required docs
3. 'unspecified ' is no longer added as "" on tf state file. Hence, it is not shown as being added repeatedly after the fix
4. 'none' is no longer added as ""
5. Modified 'prio' to accept more levels