### PR TITLE
[aci_l3_ext_subnet] Parameter depreceation and documentation.

### DIFF
--- a/examples/l3out_extension_subnet/.terraform.lock.hcl
+++ b/examples/l3out_extension_subnet/.terraform.lock.hcl
@@ -1,0 +1,37 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/ciscodevnet/aci" {
+  version = "0.7.1"
+  hashes = [
+    "h1:4f57JmcJvsJVcZmKdSyHtTdAfxuCVrtMTcYozEfcuXI=",
+    "h1:5XS0Q0gEN1xDNFSU4HPdePHWqJb9FNEWRFtSJ7SSrQY=",
+    "h1:6DxsyPD4rVJmUsPB/oOlcYkEHqKQeQW6xcyIB0LlJ4E=",
+    "h1:7TAwcI0WMs1WgDpVXM5ipvIpms2Jh0X7egyEfO/F194=",
+    "h1:FFASj+h/TgMoycpWAFZVoGafKIE/UTsDPLUExqf9Nmg=",
+    "h1:W7e4qRQkygtci8xSFSoEtYyT2CCfkPAIsBYSSJMhWLM=",
+    "h1:XTtv7p1HQYXUmayuEIGT5Yni08ChHsMkVl4wuAs7R8s=",
+    "h1:f6cigpcHSJK1rKmpwKZ0GQS8Sw4rBkixX/K9dVrTgJ0=",
+    "h1:gG5ntXUK2TxeSGBuktExEx6mhHugcgSBWsWD5qZ8CXY=",
+    "h1:lLKLURIQQXzwWH+nmb8A2X3vc7rKrNxRkhs/V7+momc=",
+    "h1:ogY9nJW9M9vv1+k+sMMYLYqs8djuLidoLeIl++3zLT0=",
+    "h1:sN3KHMrAOQhPK/6HuXpfx9rxZCFSRr+JhRFB9P9la+w=",
+    "zh:00f72f8fb8681225c9deb86b1037d864b5e70d694dd325d0701ceee4ad9a11e3",
+    "zh:2177fcd36a03a814333221edfbebee06052b0b48ec504e4f685df092da5ea185",
+    "zh:27e7cbc2a20332a67ed008c5012fba85df70adc0028a0cb12f56ee3a5397d028",
+    "zh:3743e0eb1bff8e8cd77de29070da3c3235e0c578af2d1282074a97de0f7c7289",
+    "zh:3e74166600c54e2d885eba46163855a61d3e2cda84dbf308e1167087af311817",
+    "zh:49987bf28360d3b8feb337091202e52a3f415f705c00db0e4118231ce2da6b5c",
+    "zh:4f2a39a6b57c856b14a9b4281172786fb1b66e04a35504c42119b4914ff08a0d",
+    "zh:63a28879b372af866d2595077c3333800c890ddd0c925074f0466a672283d509",
+    "zh:644de5511a4d03e4d2dd75d78ada587b4324f4f5c64991aa5d2b1b924f8f489d",
+    "zh:6ad399cf3edbc29d7daf7bfc463a6d18d578a10a26e08fc8b55b6959136cdb11",
+    "zh:85257b09f6b54a43bf610668c6fd1456e2aea714199bcf94bed53ab10bacf099",
+    "zh:a6f17669ad0221c1fdd621f9cddfd4e258e0eba3d04e6bf511153d25430470ed",
+    "zh:b1a5e2bd9ece21c62880d6425ae4676d3ba158c56a2debc327c916ade8ffd40f",
+    "zh:b9890579978875b45f5484150ae7fbd75c792b9462fd52ddbbb693ba52b89b4a",
+    "zh:eb128c57692f7cd5a8c5270ba134a3dfac61e5595f75414b4c19b5eac89f9aea",
+    "zh:fc8d339a5d00c02305e8926fcd1c9412667f3954615924ed0e3017c5132b1665",
+    "zh:fc8e0495fd12fcda0bb05b3d0d259523a2a26e81c5f101b88c4fbaf4ac1d5dd5",
+  ]
+}

--- a/examples/l3out_extension_subnet/main.tf
+++ b/examples/l3out_extension_subnet/main.tf
@@ -1,0 +1,79 @@
+terraform {
+  required_providers {
+    aci = {
+      source = "ciscodevnet/aci"
+    }
+  }
+}
+
+#configure provider with your cisco aci credentials.
+provider "aci" {
+  username = "admin"                  # <APIC username>
+  password = "ins3965!"               # <APIC pwd>
+  url      = "https://10.23.248.103/" # <cloud APIC URL>
+  insecure = true
+}
+
+resource "aci_tenant" "tenant01" {
+  name        = "tenant01"
+  description = "This tenant is created by terraform ACI provider"
+}
+
+resource "aci_l3_domain_profile" "l3_domain_profile" {
+  name = "l3extDomp1"
+}
+
+resource "aci_vrf" "vrf1" {
+  tenant_dn          = aci_tenant.tenant01.id
+  bd_enforced_enable = "no"
+  knw_mcast_act      = "permit"
+  name               = "vrf1"
+  pc_enf_dir         = "ingress"
+  pc_enf_pref        = "enforced"
+}
+
+resource "aci_l3_outside" "l3_outside" {
+  tenant_dn                    = aci_tenant.tenant01.id
+  name                         = "demo_l3out"
+  annotation                   = "tag_l3out"
+  name_alias                   = "alias_out"
+  target_dscp                  = "unspecified"
+  relation_l3ext_rs_ectx       = aci_vrf.vrf1.id
+  relation_l3ext_rs_l3_dom_att = aci_l3_domain_profile.l3_domain_profile.id
+}
+
+
+resource "aci_external_network_instance_profile" "l3out_extepg" {
+  l3_outside_dn = aci_l3_outside.l3_outside.id
+  description   = "ExtEpg for Terraform l3out"
+  name          = "l3out_extepg"
+}
+
+resource "aci_bgp_route_control_profile" "bgp_route_control_profile" {
+  parent_dn = aci_tenant.tenant01.id
+  name      = "bgp_route_control_profile"
+}
+
+resource "aci_l3_ext_subnet" "l3out_extepg_subnet" {
+  external_network_instance_profile_dn = aci_external_network_instance_profile.l3out_extepg.id
+  ip                                   = "10.10.10.10/24"
+  aggregate                            = "shared-rtctrl"
+  annotation                           = "tag_ext_subnet"
+  name_alias                           = "alias_ext_subnet"
+  scope                                = ["import-rtctrl", "export-rtctrl", "import-security"]
+  relation_l3ext_rs_subnet_to_profile {
+    tn_rtctrl_profile_dn = aci_bgp_route_control_profile.bgp_route_control_profile.id
+    direction            = "import"
+  }
+}
+
+// The below was of represnting tn_rtctrl_profile_name parameter will be deprecated.
+resource "aci_l3_ext_subnet" "l3out_extepg_subnet02" {
+  external_network_instance_profile_dn = aci_external_network_instance_profile.l3out_extepg.id
+  ip                                   = "10.10.10.10/16"
+  scope                                = ["import-rtctrl"]
+  relation_l3ext_rs_subnet_to_profile {
+    tn_rtctrl_profile_name = "test"
+    direction              = "import"
+  }
+}

--- a/website/docs/r/l3_ext_subnet.html.markdown
+++ b/website/docs/r/l3_ext_subnet.html.markdown
@@ -9,6 +9,8 @@ description: |-
 # aci_l3_ext_subnet #
 Manages ACI l3 extension subnet
 
+Tenant -> Networking -> L3Outs -> External EPGs -> Subnets -> Route Control Profile
+
 ## Example Usage ##
 
 ```hcl
@@ -20,7 +22,11 @@ Manages ACI l3 extension subnet
 	  aggregate                             = "shared-rtctrl"
 	  annotation                            = "tag_ext_subnet"
 	  name_alias                            = "alias_ext_subnet"
-	  scope                                 = ["import-security"]
+	  scope                                 = ["import-rtctrl", "export-rtctrl", "import-security"]
+	  relation_l3ext_rs_subnet_to_profile {
+		tn_rtctrl_profile_dn  = aci_bgp_route_control_profile.bgp_route_control_profile.id
+		direction = "import"
+	  }
 	}
 
 ```
@@ -34,10 +40,12 @@ Manages ACI l3 extension subnet
 * `name_alias` - (Optional) name_alias for object l3 extension subnet.
 * `scope` - (Optional) The list of domain applicable to the capability. Allowed values are "import-rtctrl", "export-rtctrl", "import-security", "shared-security" and "shared-rtctrl". Default is "import-security".
 
-* `relation_l3ext_rs_subnet_to_profile` - (Optional) Relation to class rtctrlProfile. Cardinality - N_TO_M. Type - Set of Map.
-                
+* `relation_l3ext_rs_subnet_to_profile` - (Optional) Relation to Route Control Profile (class rtctrlProfile). Cardinality - N_TO_ONE. Type - Set of Map.
+	* `relation_l3ext_rs_subnet_to_profile.tn_rtctrl_profile_name` - **Deprecated** (Required if tn_rtctrl_profile_dn is not used)(Optional) Associates the external EPGs with the route control profiles.
+	* `relation_l3ext_rs_subnet_to_profile.tn_rtctrl_profile_dn` - (Optional) Associates the external EPGs with the route control profiles.
+	* `relation_l3ext_rs_subnet_to_profile.direction` - (Required) Relation to configure route map for each BGP peer in the inbound and outbound directions.
 * `relation_l3ext_rs_subnet_to_rt_summ` - (Optional) Relation to class rtsumARtSummPol. Cardinality - N_TO_ONE. Type - String.
-                
+
 
 
 ## Attribute Reference


### PR DESCRIPTION
Deprecated tn_rtctrl_profile_name and added tn_rtctrl_profile_dn and  mentioned them in documentation