### PR TITLE
Add option to unselect garp in resource_aci_fvbd

### DIFF
--- a/aci/resource_aci_fvbd.go
+++ b/aci/resource_aci_fvbd.go
@@ -1066,6 +1066,10 @@ func resourceAciBridgeDomainRead(ctx context.Context, d *schema.ResourceData, m 
 	dn := d.Id()
 	fvBD, err := getRemoteBridgeDomain(aciClient, dn)
 
+	if fvBD.EpMoveDetectMode == "" {
+		fvBD.EpMoveDetectMode = "disable"
+	}
+
 	if err != nil {
 		d.SetId("")
 		return nil

--- a/aci/resource_aci_fvbd.go
+++ b/aci/resource_aci_fvbd.go
@@ -71,17 +71,14 @@ func resourceAciBridgeDomain() *schema.Resource {
 				}, false),
 			},
 
-			"ep_move_detect_mode": {
-				Type:     schema.TypeList,
+			"ep_move_detect_mode": &schema.Schema{
+				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-					ValidateFunc: validation.StringInSlice([]string{
-						"garp",
-						"disable",
-					}, false),
-				},
+				ValidateFunc: validation.StringInSlice([]string{
+					"garp",
+					"disable",
+				}, false),
 			},
 			"host_based_routing": &schema.Schema{
 				Type:     schema.TypeString,
@@ -456,15 +453,10 @@ func resourceAciBridgeDomainCreate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if EpMoveDetectMode, ok := d.GetOk("ep_move_detect_mode"); ok {
-		epMoveDetectModeList := make([]string, 0, 1)
-		for _, val := range EpMoveDetectMode.([]interface{}) {
-			epMoveDetectModeList = append(epMoveDetectModeList, val.(string))
-		}
-		EpMoveDetectMode := strings.Join(epMoveDetectModeList, ",")
 		if EpMoveDetectMode == "disable" {
 			fvBDAttr.EpMoveDetectMode = "{}"
 		} else {
-			fvBDAttr.EpMoveDetectMode = EpMoveDetectMode
+			fvBDAttr.EpMoveDetectMode = EpMoveDetectMode.(string)
 		}
 	}
 
@@ -742,15 +734,10 @@ func resourceAciBridgeDomainUpdate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if EpMoveDetectMode, ok := d.GetOk("ep_move_detect_mode"); ok {
-		epMoveDetectModeList := make([]string, 0, 1)
-		for _, val := range EpMoveDetectMode.([]interface{}) {
-			epMoveDetectModeList = append(epMoveDetectModeList, val.(string))
-		}
-		EpMoveDetectMode := strings.Join(epMoveDetectModeList, ",")
 		if EpMoveDetectMode == "disable" {
 			fvBDAttr.EpMoveDetectMode = "{}"
 		} else {
-			fvBDAttr.EpMoveDetectMode = EpMoveDetectMode
+			fvBDAttr.EpMoveDetectMode = EpMoveDetectMode.(string)
 		}
 	}
 

--- a/aci/resource_aci_fvbd.go
+++ b/aci/resource_aci_fvbd.go
@@ -71,15 +71,18 @@ func resourceAciBridgeDomain() *schema.Resource {
 				}, false),
 			},
 
-			"ep_move_detect_mode": &schema.Schema{
-				Type:     schema.TypeString,
+			"ep_move_detect_mode": {
+				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"garp",
-				}, false),
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{
+						"garp",
+						"disable",
+					}, false),
+				},
 			},
-
 			"host_based_routing": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -451,9 +454,20 @@ func resourceAciBridgeDomainCreate(ctx context.Context, d *schema.ResourceData, 
 	if EpClear, ok := d.GetOk("ep_clear"); ok {
 		fvBDAttr.EpClear = EpClear.(string)
 	}
+
 	if EpMoveDetectMode, ok := d.GetOk("ep_move_detect_mode"); ok {
-		fvBDAttr.EpMoveDetectMode = EpMoveDetectMode.(string)
+		epMoveDetectModeList := make([]string, 0, 1)
+		for _, val := range EpMoveDetectMode.([]interface{}) {
+			epMoveDetectModeList = append(epMoveDetectModeList, val.(string))
+		}
+		EpMoveDetectMode := strings.Join(epMoveDetectModeList, ",")
+		if EpMoveDetectMode == "disable" {
+			fvBDAttr.EpMoveDetectMode = "{}"
+		} else {
+			fvBDAttr.EpMoveDetectMode = EpMoveDetectMode
+		}
 	}
+
 	if HostBasedRouting, ok := d.GetOk("host_based_routing"); ok {
 		fvBDAttr.HostBasedRouting = HostBasedRouting.(string)
 	}
@@ -726,9 +740,20 @@ func resourceAciBridgeDomainUpdate(ctx context.Context, d *schema.ResourceData, 
 	if EpClear, ok := d.GetOk("ep_clear"); ok {
 		fvBDAttr.EpClear = EpClear.(string)
 	}
+
 	if EpMoveDetectMode, ok := d.GetOk("ep_move_detect_mode"); ok {
-		fvBDAttr.EpMoveDetectMode = EpMoveDetectMode.(string)
+		epMoveDetectModeList := make([]string, 0, 1)
+		for _, val := range EpMoveDetectMode.([]interface{}) {
+			epMoveDetectModeList = append(epMoveDetectModeList, val.(string))
+		}
+		EpMoveDetectMode := strings.Join(epMoveDetectModeList, ",")
+		if EpMoveDetectMode == "disable" {
+			fvBDAttr.EpMoveDetectMode = "{}"
+		} else {
+			fvBDAttr.EpMoveDetectMode = EpMoveDetectMode
+		}
 	}
+
 	if HostBasedRouting, ok := d.GetOk("host_based_routing"); ok {
 		fvBDAttr.HostBasedRouting = HostBasedRouting.(string)
 	}

--- a/examples/bridge_domain/bd.tf
+++ b/examples/bridge_domain/bd.tf
@@ -11,7 +11,7 @@ resource "aci_bridge_domain" "demobd" {
   optimize_wan_bandwidth         = "no"
   arp_flood                      = "no"
   ep_clear                       = "no"
-  ep_move_detect_mode            = ["garp"]
+  ep_move_detect_mode            = "garp"
   intersite_bum_traffic_allow    = "yes"
   intersite_l2_stretch           = "yes"
   ip_learning                    = "yes"

--- a/examples/bridge_domain/bd.tf
+++ b/examples/bridge_domain/bd.tf
@@ -11,7 +11,7 @@ resource "aci_bridge_domain" "demobd" {
   optimize_wan_bandwidth         = "no"
   arp_flood                      = "no"
   ep_clear                       = "no"
-  ep_move_detect_mode            = "garp"
+  ep_move_detect_mode            = ["garp"]
   intersite_bum_traffic_allow    = "yes"
   intersite_l2_stretch           = "yes"
   ip_learning                    = "yes"

--- a/website/docs/r/bridge_domain.html.markdown
+++ b/website/docs/r/bridge_domain.html.markdown
@@ -24,7 +24,7 @@ Manages ACI Bridge Domain
 ```hcl
 	resource "aci_bridge_domain" "foobridge_domain" {
 		tenant_dn                   = aci_tenant.tenant_for_bd.id
-		description                 = "from terraform"
+		description                 = "created from terraform"
 		name                        = "demo_bd"
 		optimize_wan_bandwidth      = "no"
 		annotation                  = "tag_bd"
@@ -50,36 +50,6 @@ Manages ACI Bridge Domain
 		vmac                        = "not-applicable"
 	}
 ```
-<<<<<<< HEAD
-
-## Argument Reference
-
-- `tenant_dn` - (Required) Distinguished name of parent Tenant object.
-- `name` - (Required) Name of Object bridge domain.
-- `optimize_wan_bandwidth` - (Optional) Flag to enable OptimizeWanBandwidth between sites. Allowed values are "yes" and "no". Default is "no".
-- `annotation` - (Optional) Annotation for object bridge domain.
-- `description` - (Optional) Description for object bridge domain.
-- `arp_flood` - (Optional) A property to specify whether ARP flooding is enabled. If flooding is disabled, unicast routing will be performed on the target IP address. Allowed values are "yes" and "no". Default is "no".
-- `ep_clear` - (Optional) Represents the parameter used by the node (i.e. Leaf) to clear all EPs in all leaves for this BD. Allowed values are "yes" and "no". Default is "no".
-- `ep_move_detect_mode` - (Optional) The End Point move detection option uses the Gratuitous Address Resolution Protocol (GARP). A gratuitous ARP is an ARP broadcast-type of packet that is used to verify that no other device on the network has the same IP address as the sending device. The only Allowed value is "garp"
-- `host_based_routing` - (Optional) Enables advertising host routes out of l3outs of this BD. Allowed values are "yes" and "no". Default is "no".
-- `intersite_bum_traffic_allow` - (Optional) Control whether BUM traffic is allowed between sites. Allowed values are "yes" and "no". Default is "no".
-- `intersite_l2_stretch` - (Optional) Flag to enable l2Stretch between sites. Allowed values are "yes" and "no". Default is "no".
-- `ip_learning` - (Optional) Endpoint Dataplane Learning. Allowed values are "yes" and "no". Default is "yes".
-- `ipv6_mcast_allow` - (Optional) Flag to indicate multicast IpV6 is allowed or not. Allowed values are "yes" and "no". Default is "no".
-- `limit_ip_learn_to_subnets` - (Optional) Limits IP address learning to the bridge domain subnets only. Every BD can have multiple subnets associated with it. By default, all IPs are learned. Allowed values are "yes" and "no". Default is "yes".
-- `ll_addr` - (Optional) Override of system generated ipv6 link-local address. Default value is "::".
-- `mac` - (Optional) The MAC address of the bridge domain (BD) or switched virtual interface (SVI). Every BD by default takes the fabric-wide default MAC address. You can override that address with a different one. By default the BD will take a 00:22:BD:F8:19:FF mac address.
-- `mcast_allow` - (Optional) Flag to indicate if multicast is enabled for IpV4 addresses. Allowed values are "yes" and "no". Default is "no".
-- `multi_dst_pkt_act` - (Optional) The multiple destination forwarding method for L2 Multicast, Broadcast, and Link Layer traffic types. Allowed values are "bd-flood", "encap-flood" and "drop". Default is "bd-flood".
-- `name_alias` - (Optional) Name alias for object bridge domain.
-- `bridge_domain_type` - (Optional) The specific type of the object or component. Allowed values are "regular" and "fc". Default is "regular".
-- `unicast_route` - (Optional) The forwarding method based on predefined forwarding criteria (IP or MAC address). Allowed values are "yes" and "no". Default is "yes".
-- `unk_mac_ucast_act` - (Optional) The forwarding method for unknown layer 2 destinations. Allowed values are "flood" and "proxy". Default is "proxy".
-- `unk_mcast_act` - (Optional) The parameter used by the node (i.e. a leaf) for forwarding data for an unknown multicast destination. Allowed values are "flood" and "opt-flood". Default is "flood".
-- `v6unk_mcast_act` - (Optional) M-cast action for object bridge_domain. Allowed values are "flood" and "opt-flood". Default is "flood".
-- `vmac` - (Optional) Virtual MAC address of the BD/SVI. This is used when the BD is extended to multiple sites using l2 Outside. Only allowed values is "not-applicable". Default value is "not-applicable".
-=======
 ## Argument Reference ##
 * `tenant_dn` - (Required) Distinguished name of parent Tenant object.
 * `name` - (Required) name of Object bridge_domain.
@@ -107,7 +77,6 @@ Allowed values: "garp" and "disable". Default is "disable". Type - List.
 * `unk_mcast_act` - (Optional) The parameter used by the node (i.e. a leaf) for forwarding data for an unknown multicast destination. Allowed values are "flood" and "opt-flood". Default is "flood".
 * `v6unk_mcast_act` - (Optional) v6unk_mcast_act for object bridge_domain.
 * `vmac` - (Optional) Virtual MAC address of the BD/SVI. This is used when the BD is extended to multiple sites using l2 Outside. Only allowed values is "not-applicable".
->>>>>>> Add option to unselect garp
 
 * `relation_fv_rs_bd_to_profile` - (Optional) Relation to L3Outs Route Map For Import and Export Route Control (Point to class rtctrlProfile). Cardinality - N_TO_ONE. Type - String.
 

--- a/website/docs/r/bridge_domain.html.markdown
+++ b/website/docs/r/bridge_domain.html.markdown
@@ -24,13 +24,13 @@ Manages ACI Bridge Domain
 ```hcl
 	resource "aci_bridge_domain" "foobridge_domain" {
 		tenant_dn                   = aci_tenant.tenant_for_bd.id
-		description                 = "created from terraform"
+		description                 = "from terraform"
 		name                        = "demo_bd"
 		optimize_wan_bandwidth      = "no"
 		annotation                  = "tag_bd"
 		arp_flood                   = "no"
 		ep_clear                    = "no"
-		ep_move_detect_mode         = ["garp"]
+		ep_move_detect_mode         = "garp"
 		host_based_routing          = "no"
 		intersite_bum_traffic_allow = "yes"
 		intersite_l2_stretch        = "yes"
@@ -50,33 +50,34 @@ Manages ACI Bridge Domain
 		vmac                        = "not-applicable"
 	}
 ```
-## Argument Reference ##
-* `tenant_dn` - (Required) Distinguished name of parent Tenant object.
-* `name` - (Required) name of Object bridge_domain.
-* `optimize_wan_bandwidth` - (Optional) Flag to enable OptimizeWanBandwidth between sites. Allowed values are "yes" and "no". Default is "no".
-* `annotation` - (Optional) annotation for object bridge_domain.
-* `arp_flood` - (Optional) A property to specify whether ARP flooding is enabled. If flooding is disabled, unicast routing will be performed on the target IP address. Allowed values are "yes" and "no". Default is "no".
-* `ep_clear` - (Optional) Represents the parameter used by the node (i.e. Leaf) to clear all EPs in all leaves for this BD. Allowed values are "yes" and "no". Default is "no".
-* `ep_move_detect_mode` - (Optional) The End Point move detection option uses the Gratuitous Address Resolution Protocol (GARP). A gratuitous ARP is an ARP broadcast-type of packet that is used to verify that no other device on the network has the same IP address as the sending device.
-Allowed values: "garp" and "disable". Default is "disable". Type - List.
-* `host_based_routing` - (Optional) enables advertising host routes out of l3outs of this BD. Allowed values are "yes" and "no". Default is "no".
-* `intersite_bum_traffic_allow` - (Optional)  Control whether BUM traffic is allowed between sites
-.Allowed values are "yes" and "no". Default is "no".
-* `intersite_l2_stretch` - (Optional) Flag to enable l2Stretch between sites. Allowed values are "yes" and "no". Default is "no".
-* `ip_learning` - (Optional) Endpoint Dataplane Learning.Allowed values are "yes" and "no". Default is "yes".
-* `ipv6_mcast_allow` - (Optional) Flag to indicate multicast IpV6 is allowed or not.Allowed values are "yes" and "no". Default is "no".
-* `limit_ip_learn_to_subnets` - (Optional) Limits IP address learning to the bridge domain subnets only. Every BD can have multiple subnets associated with it. By default, all IPs are learned. Allowed values are "yes" and "no". Default is "yes".
-* `ll_addr` - (Optional) override of system generated ipv6 link-local address.
-* `mac` - (Optional) The MAC address of the bridge domain (BD) or switched virtual interface (SVI). Every BD by default takes the fabric-wide default MAC address. You can override that address with a different one. By default the BD will take a 00:22:BD:F8:19:FF mac address.
-* `mcast_allow` - (Optional) Flag to indicate if multicast is enabled for IpV4 addresses. Allowed values are "yes" and "no". Default is "no".
-* `multi_dst_pkt_act` - (Optional) The multiple destination forwarding method for L2 Multicast, Broadcast, and Link Layer traffic types. Allowed values are "bd-flood", "encap-flood" and "drop". Default is "bd-flood".
-* `name_alias` - (Optional) name_alias for object bridge_domain.
-* `bridge_domain_type` - (Optional) The specific type of the object or component. Allowed values are "regular" and "fc". Default is "regular".
-* `unicast_route` - (Optional) The forwarding method based on predefined forwarding criteria (IP or MAC address). Allowed values are "yes" and "no". Default is "yes".
-* `unk_mac_ucast_act` - (Optional) The forwarding method for unknown layer 2 destinations. Allowed values are "flood" and "proxy". Default is "proxy".
-* `unk_mcast_act` - (Optional) The parameter used by the node (i.e. a leaf) for forwarding data for an unknown multicast destination. Allowed values are "flood" and "opt-flood". Default is "flood".
-* `v6unk_mcast_act` - (Optional) v6unk_mcast_act for object bridge_domain.
-* `vmac` - (Optional) Virtual MAC address of the BD/SVI. This is used when the BD is extended to multiple sites using l2 Outside. Only allowed values is "not-applicable".
+
+## Argument Reference
+
+- `tenant_dn` - (Required) Distinguished name of parent Tenant object.
+- `name` - (Required) Name of Object bridge domain.
+- `optimize_wan_bandwidth` - (Optional) Flag to enable OptimizeWanBandwidth between sites. Allowed values are "yes" and "no". Default is "no".
+- `annotation` - (Optional) Annotation for object bridge domain.
+- `description` - (Optional) Description for object bridge domain.
+- `arp_flood` - (Optional) A property to specify whether ARP flooding is enabled. If flooding is disabled, unicast routing will be performed on the target IP address. Allowed values are "yes" and "no". Default is "no".
+- `ep_clear` - (Optional) Represents the parameter used by the node (i.e. Leaf) to clear all EPs in all leaves for this BD. Allowed values are "yes" and "no". Default is "no".
+- `ep_move_detect_mode` - (Optional) The End Point move detection option uses the Gratuitous Address Resolution Protocol (GARP). A gratuitous ARP is an ARP broadcast-type of packet that is used to verify that no other device on the network has the same IP address as the sending device. Allowed values are "garp" and "disable". Default value is "disable". Type - String.
+- `host_based_routing` - (Optional) Enables advertising host routes out of l3outs of this BD. Allowed values are "yes" and "no". Default is "no".
+- `intersite_bum_traffic_allow` - (Optional) Control whether BUM traffic is allowed between sites. Allowed values are "yes" and "no". Default is "no".
+- `intersite_l2_stretch` - (Optional) Flag to enable l2Stretch between sites. Allowed values are "yes" and "no". Default is "no".
+- `ip_learning` - (Optional) Endpoint Dataplane Learning. Allowed values are "yes" and "no". Default is "yes".
+- `ipv6_mcast_allow` - (Optional) Flag to indicate multicast IpV6 is allowed or not. Allowed values are "yes" and "no". Default is "no".
+- `limit_ip_learn_to_subnets` - (Optional) Limits IP address learning to the bridge domain subnets only. Every BD can have multiple subnets associated with it. By default, all IPs are learned. Allowed values are "yes" and "no". Default is "yes".
+- `ll_addr` - (Optional) Override of system generated ipv6 link-local address. Default value is "::".
+- `mac` - (Optional) The MAC address of the bridge domain (BD) or switched virtual interface (SVI). Every BD by default takes the fabric-wide default MAC address. You can override that address with a different one. By default the BD will take a 00:22:BD:F8:19:FF mac address.
+- `mcast_allow` - (Optional) Flag to indicate if multicast is enabled for IpV4 addresses. Allowed values are "yes" and "no". Default is "no".
+- `multi_dst_pkt_act` - (Optional) The multiple destination forwarding method for L2 Multicast, Broadcast, and Link Layer traffic types. Allowed values are "bd-flood", "encap-flood" and "drop". Default is "bd-flood".
+- `name_alias` - (Optional) Name alias for object bridge domain.
+- `bridge_domain_type` - (Optional) The specific type of the object or component. Allowed values are "regular" and "fc". Default is "regular".
+- `unicast_route` - (Optional) The forwarding method based on predefined forwarding criteria (IP or MAC address). Allowed values are "yes" and "no". Default is "yes".
+- `unk_mac_ucast_act` - (Optional) The forwarding method for unknown layer 2 destinations. Allowed values are "flood" and "proxy". Default is "proxy".
+- `unk_mcast_act` - (Optional) The parameter used by the node (i.e. a leaf) for forwarding data for an unknown multicast destination. Allowed values are "flood" and "opt-flood". Default is "flood".
+- `v6unk_mcast_act` - (Optional) M-cast action for object bridge_domain. Allowed values are "flood" and "opt-flood". Default is "flood".
+- `vmac` - (Optional) Virtual MAC address of the BD/SVI. This is used when the BD is extended to multiple sites using l2 Outside. Only allowed values is "not-applicable". Default value is "not-applicable".
 
 * `relation_fv_rs_bd_to_profile` - (Optional) Relation to L3Outs Route Map For Import and Export Route Control (Point to class rtctrlProfile). Cardinality - N_TO_ONE. Type - String.
 

--- a/website/docs/r/bridge_domain.html.markdown
+++ b/website/docs/r/bridge_domain.html.markdown
@@ -30,7 +30,7 @@ Manages ACI Bridge Domain
 		annotation                  = "tag_bd"
 		arp_flood                   = "no"
 		ep_clear                    = "no"
-		ep_move_detect_mode         = "garp"
+		ep_move_detect_mode         = ["garp"]
 		host_based_routing          = "no"
 		intersite_bum_traffic_allow = "yes"
 		intersite_l2_stretch        = "yes"
@@ -50,6 +50,7 @@ Manages ACI Bridge Domain
 		vmac                        = "not-applicable"
 	}
 ```
+<<<<<<< HEAD
 
 ## Argument Reference
 
@@ -78,6 +79,35 @@ Manages ACI Bridge Domain
 - `unk_mcast_act` - (Optional) The parameter used by the node (i.e. a leaf) for forwarding data for an unknown multicast destination. Allowed values are "flood" and "opt-flood". Default is "flood".
 - `v6unk_mcast_act` - (Optional) M-cast action for object bridge_domain. Allowed values are "flood" and "opt-flood". Default is "flood".
 - `vmac` - (Optional) Virtual MAC address of the BD/SVI. This is used when the BD is extended to multiple sites using l2 Outside. Only allowed values is "not-applicable". Default value is "not-applicable".
+=======
+## Argument Reference ##
+* `tenant_dn` - (Required) Distinguished name of parent Tenant object.
+* `name` - (Required) name of Object bridge_domain.
+* `optimize_wan_bandwidth` - (Optional) Flag to enable OptimizeWanBandwidth between sites. Allowed values are "yes" and "no". Default is "no".
+* `annotation` - (Optional) annotation for object bridge_domain.
+* `arp_flood` - (Optional) A property to specify whether ARP flooding is enabled. If flooding is disabled, unicast routing will be performed on the target IP address. Allowed values are "yes" and "no". Default is "no".
+* `ep_clear` - (Optional) Represents the parameter used by the node (i.e. Leaf) to clear all EPs in all leaves for this BD. Allowed values are "yes" and "no". Default is "no".
+* `ep_move_detect_mode` - (Optional) The End Point move detection option uses the Gratuitous Address Resolution Protocol (GARP). A gratuitous ARP is an ARP broadcast-type of packet that is used to verify that no other device on the network has the same IP address as the sending device.
+Allowed values: "garp" and "disable". Default is "disable". Type - List.
+* `host_based_routing` - (Optional) enables advertising host routes out of l3outs of this BD. Allowed values are "yes" and "no". Default is "no".
+* `intersite_bum_traffic_allow` - (Optional)  Control whether BUM traffic is allowed between sites
+.Allowed values are "yes" and "no". Default is "no".
+* `intersite_l2_stretch` - (Optional) Flag to enable l2Stretch between sites. Allowed values are "yes" and "no". Default is "no".
+* `ip_learning` - (Optional) Endpoint Dataplane Learning.Allowed values are "yes" and "no". Default is "yes".
+* `ipv6_mcast_allow` - (Optional) Flag to indicate multicast IpV6 is allowed or not.Allowed values are "yes" and "no". Default is "no".
+* `limit_ip_learn_to_subnets` - (Optional) Limits IP address learning to the bridge domain subnets only. Every BD can have multiple subnets associated with it. By default, all IPs are learned. Allowed values are "yes" and "no". Default is "yes".
+* `ll_addr` - (Optional) override of system generated ipv6 link-local address.
+* `mac` - (Optional) The MAC address of the bridge domain (BD) or switched virtual interface (SVI). Every BD by default takes the fabric-wide default MAC address. You can override that address with a different one. By default the BD will take a 00:22:BD:F8:19:FF mac address.
+* `mcast_allow` - (Optional) Flag to indicate if multicast is enabled for IpV4 addresses. Allowed values are "yes" and "no". Default is "no".
+* `multi_dst_pkt_act` - (Optional) The multiple destination forwarding method for L2 Multicast, Broadcast, and Link Layer traffic types. Allowed values are "bd-flood", "encap-flood" and "drop". Default is "bd-flood".
+* `name_alias` - (Optional) name_alias for object bridge_domain.
+* `bridge_domain_type` - (Optional) The specific type of the object or component. Allowed values are "regular" and "fc". Default is "regular".
+* `unicast_route` - (Optional) The forwarding method based on predefined forwarding criteria (IP or MAC address). Allowed values are "yes" and "no". Default is "yes".
+* `unk_mac_ucast_act` - (Optional) The forwarding method for unknown layer 2 destinations. Allowed values are "flood" and "proxy". Default is "proxy".
+* `unk_mcast_act` - (Optional) The parameter used by the node (i.e. a leaf) for forwarding data for an unknown multicast destination. Allowed values are "flood" and "opt-flood". Default is "flood".
+* `v6unk_mcast_act` - (Optional) v6unk_mcast_act for object bridge_domain.
+* `vmac` - (Optional) Virtual MAC address of the BD/SVI. This is used when the BD is extended to multiple sites using l2 Outside. Only allowed values is "not-applicable".
+>>>>>>> Add option to unselect garp
 
 * `relation_fv_rs_bd_to_profile` - (Optional) Relation to L3Outs Route Map For Import and Export Route Control (Point to class rtctrlProfile). Cardinality - N_TO_ONE. Type - String.
 


### PR DESCRIPTION
1. Add option "disable" which unselects "garp". 
2. Though "disable" is used as the attribute, "" is being used in the payload. So "disable" is like an alias.
Example:
  ep_move_detect_mode            = ["garp"]
or
  ep_move_detect_mode            = ["disable"]

Includes updated doc and example.
Tried and tested.
