### PR TITLE
Removed unused module attributes for aci_external_network_instance_profile

### DIFF
--- a/aci/resource_aci_l3extinstp.go
+++ b/aci/resource_aci_l3extinstp.go
@@ -143,12 +143,14 @@ func resourceAciExternalNetworkInstanceProfile() *schema.Resource {
 			"relation_l3ext_rs_l3_inst_p_to_dom_p": &schema.Schema{
 				Type: schema.TypeString,
 
-				Optional: true,
+				Optional:   true,
+				Deprecated: "relation_l3ext_rs_l3_inst_p_to_dom_p attribute is no longer available",
 			},
 			"relation_l3ext_rs_inst_p_to_nat_mapping_epg": &schema.Schema{
 				Type: schema.TypeString,
 
-				Optional: true,
+				Optional:   true,
+				Deprecated: "relation_l3ext_rs_inst_p_to_nat_mapping_epg attribute is no longer available",
 			},
 			"relation_fv_rs_cons_if": &schema.Schema{
 				Type:     schema.TypeSet,
@@ -157,9 +159,10 @@ func resourceAciExternalNetworkInstanceProfile() *schema.Resource {
 				Set:      schema.HashString,
 			},
 			"relation_fv_rs_cust_qos_pol": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-				Optional: true,
+				Type:       schema.TypeString,
+				Computed:   true,
+				Optional:   true,
+				Deprecated: "relation_fv_rs_cust_qos_pol attribute is no longer available",
 			},
 			"relation_l3ext_rs_inst_p_to_profile": &schema.Schema{
 				Type:     schema.TypeSet,
@@ -190,10 +193,11 @@ func resourceAciExternalNetworkInstanceProfile() *schema.Resource {
 				Set:      schema.HashString,
 			},
 			"relation_fv_rs_intra_epg": &schema.Schema{
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Optional: true,
-				Set:      schema.HashString,
+				Type:       schema.TypeSet,
+				Elem:       &schema.Schema{Type: schema.TypeString},
+				Optional:   true,
+				Set:        schema.HashString,
+				Deprecated: "relation_fv_rs_intra_epg attribute is no longer available",
 			},
 		}),
 	}

--- a/website/docs/r/external_network_instance_profile.html.markdown
+++ b/website/docs/r/external_network_instance_profile.html.markdown
@@ -45,14 +45,10 @@ Manages ACI External Network Instance Profile
 
 - `relation_fv_rs_sec_inherited` - (Optional) Relation to class fvEPg. Cardinality - N_TO_M. Type - Set of String.
 - `relation_fv_rs_prov` - (Optional) Relation to class vzBrCP. Cardinality - N_TO_M. Type - Set of String.
-- `relation_l3ext_rs_l3_inst_p_to_dom_p` - (Optional) Relation to class extnwDomP. Cardinality - N_TO_ONE. Type - String.
-- `relation_l3ext_rs_inst_p_to_nat_mapping_epg` - (Optional) Relation to class fvAEPg. Cardinality - N_TO_ONE. Type - String.
 - `relation_fv_rs_cons_if` - (Optional) Relation to class vzCPIf. Cardinality - N_TO_M. Type - Set of String.
-- `relation_fv_rs_cust_qos_pol` - (Optional) Relation to class qosCustomPol. Cardinality - N_TO_ONE. Type - String.
 - `relation_l3ext_rs_inst_p_to_profile` - (Optional) Relation to class rtctrlProfile. Cardinality - N_TO_M. Type - Set of Map.
 - `relation_fv_rs_cons` - (Optional) Relation to class vzBrCP. Cardinality - N_TO_M. Type - Set of String.
 - `relation_fv_rs_prot_by` - (Optional) Relation to class vzTaboo. Cardinality - N_TO_M. Type - Set of String.
-- `relation_fv_rs_intra_epg` - (Optional) Relation to class vzBrCP. Cardinality - N_TO_M. Type - Set of String.
 
 ## Attribute Reference
 


### PR DESCRIPTION
Note:

Removed unused module attributes for aci_external_network_instance_profile document file
Added Deprecation Message on aci_l3extinstp module.