### PR TITLE
[bug_fix] Allows user to enter value between 0-255 for "prot" in [resource_aci_vzentry]

### DIFF
--- a/website/docs/r/filter_entry.html.markdown
+++ b/website/docs/r/filter_entry.html.markdown
@@ -50,7 +50,7 @@ Allowed values: "unspecified", "ftpData", "smtp", "dns", "http","pop3", "https",
 * `icmpv6_t` - (Optional) ICMPv6 message type; used when ip_protocol is icmpv6. Allowed values are "unspecified", "dst-unreach", "time-exceeded", "echo-req", "echo-rep", "nbr-solicit", "nbr-advert" and "redirect". Default is "unspecified".
 * `match_dscp` - (Optional) The matching differentiated services code point (DSCP) of the path attached to the layer 3 outside profile. Allowed values are "CS0", "CS1", "AF11",	"AF12",	"AF13",	"CS2",	"AF21",	"AF22",	"AF23",	"CS3",	"AF31",	"AF32",	"AF33",	"CS4",	"AF41",	"AF42",	"AF43",	"CS5",	"VA",	"EF",	"CS6",	"CS7"	and "unspecified". Default is "unspecified".
 * `name_alias` - (Optional) Name alias for object filter entry.
-* `prot` - (Optional) Level 3 ip protocol. Allowed values are "unspecified", "icmp", "igmp", "tcp", "egp", "igp", "udp", "icmpv6", "eigrp", "ospfigp", "pim" and "l2tp". Default is "unspecified".
+* `prot` - (Optional) Level 3 IP protocol. Allowed values are "unspecified", "icmp", "igmp", "tcp", "egp", "igp", "udp", "icmpv6", "eigrp", "ospfigp", "pim", "l2tp" and a number between "0" and "255". Default is "unspecified".
 * `s_from_port` - (Optional) Source From Port. Accepted values are any valid TCP/UDP port range. Default is "unspecified".
 Allowed values: "unspecified", "ftpData", "smtp", "dns", "http","pop3", "https", "rtsp"
 * `s_to_port` - (Optional) Source To Port. Accepted values are any valid TCP/UDP port range. Default is "unspecified".


### PR DESCRIPTION
Allows user to enter value between 0-255 for "prot" and also fixes its idempotency when a value of protocol is entered in place of name.