### PR TITLE
Added none value to Ctrl attribute to manage Control State

### DIFF
--- a/aci/resource_aci_bfdifpol.go
+++ b/aci/resource_aci_bfdifpol.go
@@ -53,7 +53,8 @@ func resourceAciBFDInterfacePolicy() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					"opt-subif", "none",
+					"opt-subif",
+					"none",
 				}, false),
 			},
 
@@ -307,6 +308,11 @@ func resourceAciBFDInterfacePolicyRead(ctx context.Context, d *schema.ResourceDa
 		d.SetId("")
 		return nil
 	}
+
+	if bfdIfPol.Ctrl == "" {
+		bfdIfPol.Ctrl = "none"
+	}
+
 	setBFDInterfacePolicyAttributes(bfdIfPol, d)
 
 	log.Printf("[DEBUG] %s: Read finished successfully", d.Id())

--- a/aci/resource_aci_bfdifpol.go
+++ b/aci/resource_aci_bfdifpol.go
@@ -53,7 +53,7 @@ func resourceAciBFDInterfacePolicy() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					"opt-subif",
+					"opt-subif", "none",
 				}, false),
 			},
 
@@ -183,7 +183,11 @@ func resourceAciBFDInterfacePolicyCreate(ctx context.Context, d *schema.Resource
 		bfdIfPolAttr.Annotation = "{}"
 	}
 	if Ctrl, ok := d.GetOk("ctrl"); ok {
-		bfdIfPolAttr.Ctrl = Ctrl.(string)
+		if Ctrl == "none" {
+			bfdIfPolAttr.Ctrl = "0"
+		} else {
+			bfdIfPolAttr.Ctrl = Ctrl.(string)
+		}
 	}
 	if DetectMult, ok := d.GetOk("detect_mult"); ok {
 		bfdIfPolAttr.DetectMult = DetectMult.(string)
@@ -243,7 +247,11 @@ func resourceAciBFDInterfacePolicyUpdate(ctx context.Context, d *schema.Resource
 		bfdIfPolAttr.Annotation = "{}"
 	}
 	if Ctrl, ok := d.GetOk("ctrl"); ok {
-		bfdIfPolAttr.Ctrl = Ctrl.(string)
+		if Ctrl == "none" {
+			bfdIfPolAttr.Ctrl = "0"
+		} else {
+			bfdIfPolAttr.Ctrl = Ctrl.(string)
+		}
 	}
 	if DetectMult, ok := d.GetOk("detect_mult"); ok {
 		bfdIfPolAttr.DetectMult = DetectMult.(string)

--- a/website/docs/r/bfd_interface_policy.html.markdown
+++ b/website/docs/r/bfd_interface_policy.html.markdown
@@ -43,7 +43,7 @@ resource "aci_bfd_interface_policy" "example" {
 * `name` - (Required) Name of object BFD Interface Policy.
 * `admin_st` - (Optional) Administrative state of the object BFD Interface Policy. Allowed values are "disabled" and "enabled". Default is "enabled".
 * `annotation` - (Optional) Annotation for object BFD Interface Policy.
-* `ctrl` - (Optional) Control state for object BFD Interface Policy. Allowed value is "opt-subif".
+* `ctrl` - (Optional) Control state for object BFD Interface Policy. Allowed values are "opt-subif" and "none". Default is "none".
 * `detect_mult` - (Optional) Detection multiplier for object BFD Interface Policy. Range: "1" - "50". Default value is "3".
 * `echo_admin_st` - (Optional) Echo mode indicator for object BFD Interface Policy. Allowed values are "disabled" and "enabled". Default is "enabled".  
 * `echo_rx_intvl` - (Optional) Echo rx interval for object BFD Interface Policy. Range: "50" - "999". Default value is "50".


### PR DESCRIPTION
Note:

Added none value to Ctrl attribute to manage Control State under Tenant Policies - BFD Interface(aci_bfd_interface_policy).