### PR TITLE
Fix for "encap" in aci_epg_to_static_path should be "Required : true"

### DIFF
--- a/aci/resource_aci_fvrspathatt.go
+++ b/aci/resource_aci_fvrspathatt.go
@@ -40,8 +40,7 @@ func resourceAciStaticPath() *schema.Resource {
 
 			"encap": &schema.Schema{
 				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Required: true,
 			},
 
 			"instr_imedcy": &schema.Schema{

--- a/website/docs/r/epg_to_static_path.html.markdown
+++ b/website/docs/r/epg_to_static_path.html.markdown
@@ -28,9 +28,9 @@ resource "aci_epg_to_static_path" "example" {
 ## Argument Reference ##
 
 * `application_epg_dn` - (Required) Distinguished name of parent ApplicationEPG object.
+* `encap` - (Required) Encapsulation of the Static Path.
 * `tdn` - (Required) tdn of Object Static Path.
 * `annotation` - (Optional) Annotation for object Static Path.
-* `encap` - (Optional) Encapsulation of the Static Path.
 * `instr_imedcy` - (Optional) Immediacy of the Static Path.
 Allowed values: "immediate", "lazy". Default value: "lazy"
 * `mode` - (Optional) Mode of the static association with the path.


### PR DESCRIPTION
This is a fix proposal for issue #844.
Two modifications have been made.

* aci/resource_aci_fvrspathatt.go
  * changed "encap" from Optional to Required
* website/docs/r/epg_to_static_path.html.markdown
  * updated the document accordingly