### PR TITLE
Created aci_cloud_vrf_leak_routes resource and data_source files

### DIFF
--- a/aci/data_source_aci_cloudleakinternalprefix.go
+++ b/aci/data_source_aci_cloudleakinternalprefix.go
@@ -1,0 +1,66 @@
+package aci
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceAciLeakInternalPrefix() *schema.Resource {
+	return &schema.Resource{
+		ReadContext:   dataSourceAciLeakInternalPrefixRead,
+		SchemaVersion: 1,
+		Schema: AppendBaseAttrSchema(AppendNameAliasAttrSchema(map[string]*schema.Schema{
+			"vrf_dn": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"leak_to": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"vrf_dn": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+		})),
+	}
+}
+
+func dataSourceAciLeakInternalPrefixRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] LeakInternalPrefix: Beginning of data source read")
+	aciClient := m.(*client.Client)
+	VRFDn := d.Get("vrf_dn").(string)
+	rn := fmt.Sprintf(models.RnleakInternalPrefix, leakInternalPrefixIp)
+	dn := fmt.Sprintf("%s/%s/%s", VRFDn, models.RnleakRoutes, rn)
+
+	LeakInternalPrefix, err := getRemoteLeakInternalPrefix(aciClient, dn)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(dn)
+
+	_, err = setLeakInternalPrefixAttributes(LeakInternalPrefix, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// leakTo - Beginning Read
+	_, err = getAndSetCloudLeakToObjects(aciClient, dn, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	// leakTo - Read finished successfully
+	log.Printf("[DEBUG] LeakInternalPrefix: %s data source read finished successfully", d.Id())
+	return nil
+}

--- a/aci/data_source_aci_leakinternalsubnet.go
+++ b/aci/data_source_aci_leakinternalsubnet.go
@@ -37,7 +37,7 @@ func dataSourceAciLeakInternalSubnet() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"vrf_dn": &schema.Schema{
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
 						},
 						// True -> public, False -> private, Default -> "inherit"
 						"allow_l3out_advertisement": &schema.Schema{
@@ -57,7 +57,7 @@ func dataSourceAciLeakInternalSubnetRead(ctx context.Context, d *schema.Resource
 	ip := d.Get("ip").(string)
 	VRFDn := d.Get("vrf_dn").(string)
 	rn := fmt.Sprintf(models.RnleakInternalSubnet, ip)
-	dn := fmt.Sprintf("%s/%s", VRFDn, rn)
+	dn := fmt.Sprintf("%s/%s/%s", VRFDn, models.RnleakRoutes, rn)
 
 	leakInternalSubnet, err := getRemoteLeakInternalSubnet(aciClient, dn)
 	if err != nil {

--- a/aci/provider.go
+++ b/aci/provider.go
@@ -319,6 +319,7 @@ func Provider() *schema.Provider {
 			"aci_ip_sla_monitoring_policy":                 resourceAciIPSLAMonitoringPolicy(),
 			"aci_bulk_epg_to_static_path":                  resourceAciBulkStaticPath(),
 			"aci_vrf_leak_epg_bd_subnet":                   resourceAciLeakInternalSubnet(),
+			"aci_cloud_vrf_leak_routes":                    resourceAciLeakInternalPrefix(),
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -559,6 +560,7 @@ func Provider() *schema.Provider {
 			"aci_ip_sla_monitoring_policy":                 dataSourceAciIPSLAMonitoringPolicy(),
 			"aci_l4_l7_deployed_graph_connector_vlan":      dataSourceAciEPgDef(),
 			"aci_vrf_leak_epg_bd_subnet":                   dataSourceAciLeakInternalSubnet(),
+			"aci_cloud_vrf_leak_routes":                    dataSourceAciLeakInternalPrefix(),
 		},
 
 		ConfigureFunc: configureClient,

--- a/aci/resource_aci_cloudleakinternalprefix.go
+++ b/aci/resource_aci_cloudleakinternalprefix.go
@@ -134,7 +134,7 @@ func resourceAciLeakInternalPrefixCreate(ctx context.Context, d *schema.Resource
 	aciClient := m.(*client.Client)
 	desc := d.Get("description").(string)
 	VRFDn := d.Get("vrf_dn").(string)
-	leakRoutesDn := VRFDn + "/" + models.RnleakRoutes
+	leakRoutesDn := fmt.Sprintf("%s/%s", VRFDn, models.RnleakRoutes)
 
 	nameAlias := ""
 	if NameAlias, ok := d.GetOk("name_alias"); ok {
@@ -202,7 +202,7 @@ func resourceAciLeakInternalPrefixUpdate(ctx context.Context, d *schema.Resource
 	aciClient := m.(*client.Client)
 	desc := d.Get("description").(string)
 	VRFDn := d.Get("vrf_dn").(string)
-	leakRoutesDn := VRFDn + "/" + models.RnleakRoutes
+	leakRoutesDn := fmt.Sprintf("%s/%s", VRFDn, models.RnleakRoutes)
 
 	nameAlias := ""
 	if NameAlias, ok := d.GetOk("name_alias"); ok {

--- a/aci/resource_aci_cloudleakinternalprefix.go
+++ b/aci/resource_aci_cloudleakinternalprefix.go
@@ -1,0 +1,385 @@
+package aci
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/container"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const leakInternalPrefixIp = "0.0.0.0/0"
+const createLeakInternalPrefixMethod = "POST"
+const cloudLeakToScope = "public"
+const leakInternalPrefixLessThanOrEqual = "32"
+
+func resourceAciLeakInternalPrefix() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAciLeakInternalPrefixCreate,
+		UpdateContext: resourceAciLeakInternalPrefixUpdate,
+		ReadContext:   resourceAciLeakInternalPrefixRead,
+		DeleteContext: resourceAciLeakInternalPrefixDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: resourceAciLeakInternalPrefixImport,
+		},
+
+		SchemaVersion: 1,
+		Schema: AppendBaseAttrSchema(AppendNameAliasAttrSchema(map[string]*schema.Schema{
+			// Source VRF DN
+			"vrf_dn": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"leak_to": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"vrf_dn": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+		})),
+	}
+}
+
+func getRemoteLeakInternalPrefix(client *client.Client, dn string) (*models.LeakInternalPrefix, error) {
+	leakInternalPrefixCont, err := client.Get(dn)
+	if err != nil {
+		return nil, err
+	}
+	leakInternalPrefix := models.LeakInternalPrefixFromContainer(leakInternalPrefixCont)
+	if leakInternalPrefix.DistinguishedName == "" {
+		return nil, fmt.Errorf("LeakInternalPrefix %s not found", dn)
+	}
+	return leakInternalPrefix, nil
+}
+
+func setLeakInternalPrefixAttributes(leakInternalPrefix *models.LeakInternalPrefix, d *schema.ResourceData) (*schema.ResourceData, error) {
+	dn := d.Id()
+	d.SetId(leakInternalPrefix.DistinguishedName)
+	d.Set("description", leakInternalPrefix.Description)
+
+	leakInternalPrefixMap, err := leakInternalPrefix.ToMap()
+	if err != nil {
+		return d, err
+	}
+	if dn != leakInternalPrefix.DistinguishedName {
+		d.Set("vrf_dn", "")
+	} else {
+		d.Set("vrf_dn", GetParentDn(dn, fmt.Sprintf("/%s/%s", models.RnleakRoutes, fmt.Sprintf(models.RnleakInternalPrefix, leakInternalPrefixMap["ip"]))))
+	}
+	d.Set("annotation", leakInternalPrefixMap["annotation"])
+	d.Set("name_alias", leakInternalPrefixMap["nameAlias"])
+	return d, nil
+}
+
+func getAndSetCloudLeakToObjects(client *client.Client, dn string, d *schema.ResourceData) (*schema.ResourceData, error) {
+	leakToObjects, err := client.ListTenantandVRFdestinationforInterVRFLeakedRoutes(dn)
+	if len(leakToObjects) >= 1 {
+		newContent := make([]map[string]string, 0, 1)
+		for _, leakToObject := range leakToObjects {
+			newContent = append(newContent, map[string]string{
+				"vrf_dn": leakToObject.ToCtxDn,
+			})
+		}
+		d.Set("leak_to", newContent)
+		return d, nil
+	} else if err != nil {
+		d.Set("leak_to", nil)
+		log.Printf("[DEBUG]: Could not find existing leakTo objects under the parent DN: %s", dn)
+	}
+	return d, nil
+}
+
+func resourceAciLeakInternalPrefixImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	log.Printf("[DEBUG] %s: Beginning Import", d.Id())
+	aciClient := m.(*client.Client)
+	dn := d.Id()
+	leakInternalPrefix, err := getRemoteLeakInternalPrefix(aciClient, dn)
+	if err != nil {
+		return nil, err
+	}
+	schemaFilled, err := setLeakInternalPrefixAttributes(leakInternalPrefix, d)
+	if err != nil {
+		return nil, err
+	}
+
+	// leakTo - Beginning Import
+	log.Printf("[DEBUG] %s: leakTo - Beginning Import with parent DN", dn)
+	_, err = getAndSetCloudLeakToObjects(aciClient, dn, d)
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("[DEBUG] %s: leakTo - Import finished successfully with parent DN", dn)
+	// leakTo - Import finished successfully
+
+	log.Printf("[DEBUG] %s: Import finished successfully", d.Id())
+	return []*schema.ResourceData{schemaFilled}, nil
+}
+
+func resourceAciLeakInternalPrefixCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] LeakInternalPrefix: Beginning Creation")
+
+	aciClient := m.(*client.Client)
+	desc := d.Get("description").(string)
+	VRFDn := d.Get("vrf_dn").(string)
+	leakRoutesDn := VRFDn + "/" + models.RnleakRoutes
+
+	nameAlias := ""
+	if NameAlias, ok := d.GetOk("name_alias"); ok {
+		nameAlias = NameAlias.(string)
+	}
+
+	annotation := ""
+	if Annotation, ok := d.GetOk("annotation"); ok {
+		annotation = Annotation.(string)
+	} else {
+		annotation = "orchestrator:terraform"
+	}
+
+	leakInternalPrefixMap := map[string]interface{}{
+		"class_name": "leakInternalPrefix",
+		"content": map[string]string{
+			"annotation": annotation,
+			"ip":         leakInternalPrefixIp,
+			"le":         leakInternalPrefixLessThanOrEqual,
+			"nameAlias":  nameAlias,
+			"descr":      desc,
+		},
+	}
+
+	leakToList := make([]interface{}, 0)
+
+	if leakToSet, ok := d.GetOk("leak_to"); ok {
+		leakToSetList := leakToSet.(*schema.Set).List()
+		resleakToList, err := getCloudLeakToObjectsWithTenantAndCtxName(leakToSetList)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		leakToList = resleakToList
+	}
+
+	leakRoutesCont, err := createCloudLeakRoutesObject(leakInternalPrefixMap, leakToList)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	httpRequestPayload, err := aciClient.MakeRestRequest(createLeakInternalPrefixMethod, fmt.Sprintf("%s/%s.json", client.DefaultMOURL, leakRoutesDn), leakRoutesCont, true)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	respCont, _, err := aciClient.Do(httpRequestPayload)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = client.CheckForErrors(respCont, createLeakInternalPrefixMethod, false)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	leakInternalPrefixDn := leakRoutesDn + "/" + fmt.Sprintf(models.RnleakInternalPrefix, leakInternalPrefixIp)
+	d.SetId(leakInternalPrefixDn)
+	log.Printf("[DEBUG] %s: Creation finished successfully", d.Id())
+	return resourceAciLeakInternalPrefixRead(ctx, d, m)
+}
+
+func resourceAciLeakInternalPrefixUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] LeakInternalPrefix: Beginning Update")
+
+	aciClient := m.(*client.Client)
+	desc := d.Get("description").(string)
+	VRFDn := d.Get("vrf_dn").(string)
+	leakRoutesDn := VRFDn + "/" + models.RnleakRoutes
+
+	nameAlias := ""
+	if NameAlias, ok := d.GetOk("name_alias"); ok {
+		nameAlias = NameAlias.(string)
+	}
+
+	annotation := ""
+	if Annotation, ok := d.GetOk("annotation"); ok {
+		annotation = Annotation.(string)
+	} else {
+		annotation = "orchestrator:terraform"
+	}
+
+	leakInternalPrefixMap := map[string]interface{}{
+		"class_name": "leakInternalPrefix",
+		"content": map[string]string{
+			"annotation": annotation,
+			"ip":         leakInternalPrefixIp,
+			"le":         leakInternalPrefixLessThanOrEqual,
+			"nameAlias":  nameAlias,
+			"descr":      desc,
+		},
+	}
+
+	leakToList := make([]interface{}, 0, 1)
+
+	if d.HasChange("leak_to") {
+		oldSchemaObjs, newSchemaObjs := d.GetChange("leak_to")
+
+		missingOldObjects := getOldObjectsNotInNew("vrf_dn", oldSchemaObjs.(*schema.Set), newSchemaObjs.(*schema.Set))
+
+		newLeakToList := newSchemaObjs.(*schema.Set).List()
+
+		for _, missingOldObject := range missingOldObjects {
+			leakToMap := map[string]interface{}{
+				"vrf_dn": missingOldObject.(map[string]interface{})["vrf_dn"],
+				"status": "deleted",
+			}
+			newLeakToList = append(newLeakToList, leakToMap)
+		}
+
+		resLeakToList, err := getCloudLeakToObjectsWithTenantAndCtxName(newLeakToList)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		leakToList = resLeakToList
+	}
+
+	leakRoutesCont, err := createCloudLeakRoutesObject(leakInternalPrefixMap, leakToList)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	httpRequestPayload, err := aciClient.MakeRestRequest(createLeakInternalPrefixMethod, fmt.Sprintf("%s/%s.json", client.DefaultMOURL, leakRoutesDn), leakRoutesCont, true)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	respCont, _, err := aciClient.Do(httpRequestPayload)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = client.CheckForErrors(respCont, createLeakInternalPrefixMethod, false)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	leakInternalPrefixDn := leakRoutesDn + "/" + fmt.Sprintf(models.RnleakInternalPrefix, leakInternalPrefixIp)
+	d.SetId(leakInternalPrefixDn)
+	log.Printf("[DEBUG] %s: Update finished successfully", d.Id())
+	return resourceAciLeakInternalPrefixRead(ctx, d, m)
+}
+
+func resourceAciLeakInternalPrefixRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] %s: Beginning Read", d.Id())
+	aciClient := m.(*client.Client)
+	dn := d.Id()
+
+	leakInternalPrefix, err := getRemoteLeakInternalPrefix(aciClient, dn)
+	if err != nil {
+		d.SetId("")
+		return diag.FromErr(err)
+	}
+
+	_, err = setLeakInternalPrefixAttributes(leakInternalPrefix, d)
+	if err != nil {
+		d.SetId("")
+		return nil
+	}
+
+	// leakTo - Beginning Read
+	log.Printf("[DEBUG] %s: leakTo - Beginning Read with parent DN", dn)
+	_, err = getAndSetCloudLeakToObjects(aciClient, dn, d)
+	if err != nil {
+		return nil
+	}
+	log.Printf("[DEBUG] %s: leakTo - Read finished successfully with parent DN", dn)
+	// leakTo - Read finished successfully
+
+	log.Printf("[DEBUG] %s: Read finished successfully", d.Id())
+	return nil
+}
+
+func resourceAciLeakInternalPrefixDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	log.Printf("[DEBUG] %s: Beginning Destroy", d.Id())
+	aciClient := m.(*client.Client)
+	dn := d.Id()
+
+	err := aciClient.DeleteByDn(dn, "leakInternalPrefix")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[DEBUG] %s: Destroy finished successfully", d.Id())
+	d.SetId("")
+	return diag.FromErr(err)
+}
+
+func createCloudLeakRoutesObject(leakInternalPrefixMap map[string]interface{}, leakToList []interface{}) (*container.Container, error) {
+	log.Printf("[DEBUG] Beginning of createCloudLeakRoutesObject")
+
+	leakRoutesJson := []byte(`
+		{
+			"leakRoutes": {
+				"attributes": {
+				}
+			}
+		}`)
+
+	leakRoutesCont, leakRoutesErr := container.ParseJSON(leakRoutesJson)
+	if leakRoutesErr != nil {
+		return nil, fmt.Errorf("leakRoutes ParseJSON Error: %v", leakRoutesErr)
+	}
+
+	leakInternalPrefixCont, leakInternalPrefixErr := preparePayload(leakInternalPrefixMap["class_name"].(string), leakInternalPrefixMap["content"].(map[string]string), leakToList)
+	if leakInternalPrefixErr != nil {
+		return nil, fmt.Errorf("leakInternalPrefix preparePayload Error: %v", leakInternalPrefixErr)
+	}
+
+	ParentObjectCreationErr := leakRoutesCont.ArrayAppend(leakInternalPrefixCont.Data(), "leakRoutes", "children")
+	if ParentObjectCreationErr != nil {
+		return nil, fmt.Errorf("ParentObjectCreation Error:: %v", ParentObjectCreationErr)
+	}
+	log.Printf("[DEBUG]: createCloudLeakRoutesObject finished successfully")
+	return leakRoutesCont, nil
+}
+
+func getCloudLeakToObjectsWithTenantAndCtxName(leakToObjects []interface{}) ([]interface{}, error) {
+	log.Printf("[DEBUG]: Beginning of getCloudLeakToObjectsWithTenantAndCtxName")
+	resLeakToMap := make([]interface{}, 0)
+	for _, leakToObjectInterface := range leakToObjects {
+		leakToObjectMap := leakToObjectInterface.(map[string]interface{})
+		if leakToObjectMap["vrf_dn"].(string) != "" {
+			vrf_dn_pattern := regexp.MustCompile(`tn?-(.+).?/ctx?-([0-9A-Za-z_\-]+).?`)
+			match_list := vrf_dn_pattern.FindStringSubmatch(leakToObjectMap["vrf_dn"].(string))
+			if len(match_list) != 3 {
+				return nil, fmt.Errorf("error occurred during the leak_to vrf_dn parsing: %s", leakToObjectMap["vrf_dn"])
+			}
+
+			leakToStatus := ""
+			if leakToObjectMap["status"] != nil {
+				leakToStatus = leakToObjectMap["status"].(string)
+			}
+
+			leakToMap := map[string]interface{}{
+				"class_name": "leakTo",
+				"content": map[string]string{
+					"ctxName":    match_list[2],
+					"scope":      cloudLeakToScope,
+					"tenantName": match_list[1],
+					"status":     leakToStatus,
+				},
+			}
+			resLeakToMap = append(resLeakToMap, leakToMap)
+		}
+	}
+	log.Printf("[DEBUG]: getCloudLeakToObjectsWithTenantAndCtxName finished successfully")
+	return resLeakToMap, nil
+}

--- a/aci/resource_aci_leakinternalsubnet.go
+++ b/aci/resource_aci_leakinternalsubnet.go
@@ -66,7 +66,8 @@ func resourceAciLeakInternalSubnet() *schema.Resource {
 								"true",  // True -> public
 								"inherit",
 							}, false),
-							Default: "inherit",
+							Default:     "inherit",
+							Description: "Must be set as true for the Cloud APIC",
 						},
 					},
 				},
@@ -220,12 +221,17 @@ func resourceAciLeakInternalSubnetCreate(ctx context.Context, d *schema.Resource
 		return diag.FromErr(err)
 	}
 
-	httpRequestPayload, err := aciClient.MakeRestRequest("POST", fmt.Sprintf("/api/node/mo/%s.json", leakRoutesDn), leakRoutesCont, true)
+	httpRequestPayload, err := aciClient.MakeRestRequest("POST", fmt.Sprintf("%s/%s.json", client.DefaultMOURL, leakRoutesDn), leakRoutesCont, true)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	_, _, err = aciClient.Do(httpRequestPayload)
+	respCont, _, err := aciClient.Do(httpRequestPayload)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = client.CheckForErrors(respCont, "POST", false)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -272,7 +278,6 @@ func resourceAciLeakInternalSubnetUpdate(ctx context.Context, d *schema.Resource
 			"scope":      leakInternalSubnetScope,
 			"nameAlias":  nameAlias,
 			"descr":      desc,
-			"status":     "modified",
 		},
 	}
 
@@ -306,12 +311,17 @@ func resourceAciLeakInternalSubnetUpdate(ctx context.Context, d *schema.Resource
 		return diag.FromErr(err)
 	}
 
-	httpRequestPayload, err := aciClient.MakeRestRequest("POST", fmt.Sprintf("/api/node/mo/%s.json", leakRoutesDn), leakRoutesCont, true)
+	httpRequestPayload, err := aciClient.MakeRestRequest("POST", fmt.Sprintf("%s/%s.json", client.DefaultMOURL, leakRoutesDn), leakRoutesCont, true)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	_, _, err = aciClient.Do(httpRequestPayload)
+	respCont, _, err := aciClient.Do(httpRequestPayload)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = client.CheckForErrors(respCont, "POST", false)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/examples/cloud_vrf_leak_routes/main.tf
+++ b/examples/cloud_vrf_leak_routes/main.tf
@@ -1,0 +1,76 @@
+terraform {
+  required_providers {
+    aci = {
+      source = "ciscodevnet/aci"
+    }
+  }
+}
+
+provider "aci" {
+  username = "" # <APIC username>
+  password = "" # <APIC pwd>
+  url      = "" # <cloud APIC URL>
+  insecure = true
+}
+
+
+resource "aci_tenant" "src_tenant" {
+  name = "src_tenant"
+}
+
+resource "aci_tenant" "dst_tenant" {
+  name = "dst_tenant"
+}
+
+resource "aci_vrf" "src_vrf" {
+  tenant_dn = aci_tenant.src_tenant.id
+  name      = "src_vrf"
+}
+
+resource "aci_vrf" "dst_vrf1" {
+  tenant_dn = aci_tenant.dst_tenant.id
+  name      = "dst_vrf1"
+}
+
+resource "aci_vrf" "dst_vrf2" {
+  tenant_dn = aci_tenant.dst_tenant.id
+  name      = "dst_vrf2"
+}
+
+resource "aci_cloud_context_profile" "src_vrf_ctx_prof" {
+  name                     = "src_vrf_ctx_prof"
+  tenant_dn                = aci_tenant.src_tenant.id
+  primary_cidr             = "10.10.10.1/24"
+  region                   = "asia-east1"
+  cloud_vendor             = "gcp"
+  relation_cloud_rs_to_ctx = aci_vrf.src_vrf.id
+}
+
+resource "aci_cloud_context_profile" "dst_vrf1_ctx_prof" {
+  name                     = "dst_vrf1_ctx_prof"
+  tenant_dn                = aci_tenant.dst_tenant.id
+  primary_cidr             = "10.10.10.2/24"
+  region                   = "asia-east1"
+  cloud_vendor             = "gcp"
+  relation_cloud_rs_to_ctx = aci_vrf.dst_vrf1.id
+}
+
+resource "aci_cloud_context_profile" "dst_vrf2_ctx_prof" {
+  name                     = "dst_vrf2_ctx_prof"
+  tenant_dn                = aci_tenant.dst_tenant.id
+  primary_cidr             = "10.10.10.3/24"
+  region                   = "asia-east1"
+  cloud_vendor             = "gcp"
+  relation_cloud_rs_to_ctx = aci_vrf.dst_vrf2.id
+}
+
+# Only for the Cloud APIC Version >= 25.0
+resource "aci_cloud_vrf_leak_routes" "cloud_internal_leak_routes" {
+  vrf_dn = aci_vrf.src_vrf.id
+  leak_to {
+    vrf_dn = aci_vrf.dst_vrf1.id
+  }
+  leak_to {
+    vrf_dn = aci_vrf.dst_vrf2.id
+  }
+}

--- a/examples/vrf_leak_epg_bd_subnet/main.tf
+++ b/examples/vrf_leak_epg_bd_subnet/main.tf
@@ -46,6 +46,6 @@ resource "aci_vrf_leak_epg_bd_subnet" "vrf_leak_epg_bd_subnet" {
   }
   leak_to {
     vrf_dn                    = aci_vrf.vrf2.id
-    allow_l3out_advertisement = true
+    allow_l3out_advertisement = true # Must be set as true for the Cloud APIC
   }
 }

--- a/examples/vrf_leak_epg_bd_subnet/main.tf
+++ b/examples/vrf_leak_epg_bd_subnet/main.tf
@@ -46,6 +46,6 @@ resource "aci_vrf_leak_epg_bd_subnet" "vrf_leak_epg_bd_subnet" {
   }
   leak_to {
     vrf_dn                    = aci_vrf.vrf2.id
-    allow_l3out_advertisement = true # Must be set as true for the Cloud APIC
+    allow_l3out_advertisement = true # Must be set as true for Cloud APIC
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-providers/terraform-provider-aci
 go 1.12
 
 require (
-	github.com/ciscoecosystem/aci-go-client v1.53.2
+	github.com/ciscoecosystem/aci-go-client v1.54.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.18.0
 )

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/ciscoecosystem/aci-go-client v1.53.2 h1:j7dXon12hXiundV/rwtRKNCYdImlvUliVPsrBVgXUMQ=
-github.com/ciscoecosystem/aci-go-client v1.53.2/go.mod h1:/ftFFEXD2Ozajs8Zc/Xw/s6bG5+d3DWQzMAifyxu/Es=
+github.com/ciscoecosystem/aci-go-client v1.54.0 h1:fZYJPnj9JXFPN0PFD5O71l1Ejnre/UfZgo3YFh83eqE=
+github.com/ciscoecosystem/aci-go-client v1.54.0/go.mod h1:/ftFFEXD2Ozajs8Zc/Xw/s6bG5+d3DWQzMAifyxu/Es=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/vendor/github.com/ciscoecosystem/aci-go-client/client/leakInternalPrefix_service.go
+++ b/vendor/github.com/ciscoecosystem/aci-go-client/client/leakInternalPrefix_service.go
@@ -1,0 +1,48 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/ciscoecosystem/aci-go-client/models"
+)
+
+func (sm *ServiceManager) CreateLeakInternalPrefix(ip string, vrf string, tenant string, description string, nameAlias string, leakInternalPrefixAttr models.LeakInternalPrefixAttributes) (*models.LeakInternalPrefix, error) {
+	rn := fmt.Sprintf(models.RnleakInternalPrefix, ip)
+	parentDn := fmt.Sprintf(models.ParentDnleakInternalPrefix, tenant, vrf)
+	leakInternalPrefix := models.NewLeakInternalPrefix(rn, parentDn, description, nameAlias, leakInternalPrefixAttr)
+	err := sm.Save(leakInternalPrefix)
+	return leakInternalPrefix, err
+}
+
+func (sm *ServiceManager) ReadLeakInternalPrefix(ip string, vrf string, tenant string) (*models.LeakInternalPrefix, error) {
+	dn := fmt.Sprintf(models.DnleakInternalPrefix, tenant, vrf, ip)
+
+	cont, err := sm.Get(dn)
+	if err != nil {
+		return nil, err
+	}
+
+	leakInternalPrefix := models.LeakInternalPrefixFromContainer(cont)
+	return leakInternalPrefix, nil
+}
+
+func (sm *ServiceManager) DeleteLeakInternalPrefix(ip string, vrf string, tenant string) error {
+	dn := fmt.Sprintf(models.DnleakInternalPrefix, tenant, vrf, ip)
+	return sm.DeleteByDn(dn, models.LeakInternalPrefixClassName)
+}
+
+func (sm *ServiceManager) UpdateLeakInternalPrefix(ip string, vrf string, tenant string, description string, nameAlias string, leakInternalPrefixAttr models.LeakInternalPrefixAttributes) (*models.LeakInternalPrefix, error) {
+	rn := fmt.Sprintf(models.RnleakInternalPrefix, ip)
+	parentDn := fmt.Sprintf(models.ParentDnleakInternalPrefix, tenant, vrf)
+	leakInternalPrefix := models.NewLeakInternalPrefix(rn, parentDn, description, nameAlias, leakInternalPrefixAttr)
+	leakInternalPrefix.Status = "modified"
+	err := sm.Save(leakInternalPrefix)
+	return leakInternalPrefix, err
+}
+
+func (sm *ServiceManager) ListLeakInternalPrefix(vrf string, tenant string) ([]*models.LeakInternalPrefix, error) {
+	dnUrl := fmt.Sprintf("%s/uni/tn-%s/ctx-%s/leakroutes/leakInternalPrefix.json", models.BaseurlStr, tenant, vrf)
+	cont, err := sm.GetViaURL(dnUrl)
+	list := models.LeakInternalPrefixListFromContainer(cont)
+	return list, err
+}

--- a/vendor/github.com/ciscoecosystem/aci-go-client/models/cloudtemplate_ext_network.go
+++ b/vendor/github.com/ciscoecosystem/aci-go-client/models/cloudtemplate_ext_network.go
@@ -25,6 +25,8 @@ type CloudTemplateforExternalNetworkAttributes struct {
 	HubNetworkName string `json:",omitempty"`
 	Name           string `json:",omitempty"`
 	VrfName        string `json:",omitempty"`
+	AllRegion      string `json:",omitempty"`
+	HostRouterName string `json:",omitempty"`
 }
 
 func NewCloudTemplateforExternalNetwork(cloudtemplateExtNetworkRn, parentDn, nameAlias string, cloudtemplateExtNetworkAttr CloudTemplateforExternalNetworkAttributes) *CloudTemplateforExternalNetwork {
@@ -62,6 +64,8 @@ func (cloudtemplateExtNetwork *CloudTemplateforExternalNetwork) ToMap() (map[str
 	A(cloudtemplateExtNetworkMap, "hubNetworkName", cloudtemplateExtNetwork.HubNetworkName)
 	A(cloudtemplateExtNetworkMap, "name", cloudtemplateExtNetwork.Name)
 	A(cloudtemplateExtNetworkMap, "vrfName", cloudtemplateExtNetwork.VrfName)
+	A(cloudtemplateExtNetworkMap, "allRegion", cloudtemplateExtNetwork.AllRegion)
+	A(cloudtemplateExtNetworkMap, "hostRouterName", cloudtemplateExtNetwork.HostRouterName)
 	return cloudtemplateExtNetworkMap, err
 }
 
@@ -82,6 +86,8 @@ func CloudTemplateforExternalNetworkFromContainerList(cont *container.Container,
 			HubNetworkName: G(CloudTemplateforExternalNetworkCont, "hubNetworkName"),
 			Name:           G(CloudTemplateforExternalNetworkCont, "name"),
 			VrfName:        G(CloudTemplateforExternalNetworkCont, "vrfName"),
+			AllRegion:      G(CloudTemplateforExternalNetworkCont, "allRegion"),
+			HostRouterName: G(CloudTemplateforExternalNetworkCont, "hostRouterName"),
 		},
 	}
 }

--- a/vendor/github.com/ciscoecosystem/aci-go-client/models/leak_internal_prefix_subnet.go
+++ b/vendor/github.com/ciscoecosystem/aci-go-client/models/leak_internal_prefix_subnet.go
@@ -1,0 +1,104 @@
+package models
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/ciscoecosystem/aci-go-client/container"
+)
+
+const (
+	DnleakInternalPrefix        = "uni/tn-%s/ctx-%s/leakroutes/leakintprefix-[%s]"
+	RnleakInternalPrefix        = "leakintprefix-[%s]"
+	ParentDnleakInternalPrefix  = "uni/tn-%s/ctx-%s/leakroutes"
+	LeakInternalPrefixClassName = "leakInternalPrefix"
+)
+
+type LeakInternalPrefix struct {
+	BaseAttributes
+	NameAliasAttribute
+	LeakInternalPrefixAttributes
+}
+
+type LeakInternalPrefixAttributes struct {
+	Annotation      string `json:",omitempty"`
+	Ip              string `json:",omitempty"`
+	Name            string `json:",omitempty"`
+	LessThanOrEqual string `json:",omitempty"`
+}
+
+func NewLeakInternalPrefix(leakInternalPrefixRn, parentDn, description, nameAlias string, leakInternalPrefixAttr LeakInternalPrefixAttributes) *LeakInternalPrefix {
+	dn := fmt.Sprintf("%s/%s", parentDn, leakInternalPrefixRn)
+	return &LeakInternalPrefix{
+		BaseAttributes: BaseAttributes{
+			DistinguishedName: dn,
+			Description:       description,
+			Status:            "created, modified",
+			ClassName:         LeakInternalPrefixClassName,
+			Rn:                leakInternalPrefixRn,
+		},
+		NameAliasAttribute: NameAliasAttribute{
+			NameAlias: nameAlias,
+		},
+		LeakInternalPrefixAttributes: leakInternalPrefixAttr,
+	}
+}
+
+func (leakInternalPrefix *LeakInternalPrefix) ToMap() (map[string]string, error) {
+	leakInternalPrefixMap, err := leakInternalPrefix.BaseAttributes.ToMap()
+	if err != nil {
+		return nil, err
+	}
+
+	alias, err := leakInternalPrefix.NameAliasAttribute.ToMap()
+	if err != nil {
+		return nil, err
+	}
+
+	for key, value := range alias {
+		A(leakInternalPrefixMap, key, value)
+	}
+
+	A(leakInternalPrefixMap, "annotation", leakInternalPrefix.Annotation)
+	A(leakInternalPrefixMap, "ip", leakInternalPrefix.Ip)
+	A(leakInternalPrefixMap, "name", leakInternalPrefix.Name)
+	A(leakInternalPrefixMap, "le", leakInternalPrefix.LessThanOrEqual)
+	return leakInternalPrefixMap, err
+}
+
+func LeakInternalPrefixFromContainerList(cont *container.Container, index int) *LeakInternalPrefix {
+	LeakInternalPrefixCont := cont.S("imdata").Index(index).S(LeakInternalPrefixClassName, "attributes")
+	return &LeakInternalPrefix{
+		BaseAttributes{
+			DistinguishedName: G(LeakInternalPrefixCont, "dn"),
+			Description:       G(LeakInternalPrefixCont, "descr"),
+			Status:            G(LeakInternalPrefixCont, "status"),
+			ClassName:         LeakInternalPrefixClassName,
+			Rn:                G(LeakInternalPrefixCont, "rn"),
+		},
+		NameAliasAttribute{
+			NameAlias: G(LeakInternalPrefixCont, "nameAlias"),
+		},
+		LeakInternalPrefixAttributes{
+			Annotation:      G(LeakInternalPrefixCont, "annotation"),
+			Ip:              G(LeakInternalPrefixCont, "ip"),
+			Name:            G(LeakInternalPrefixCont, "name"),
+			LessThanOrEqual: G(LeakInternalPrefixCont, "le"),
+		},
+	}
+}
+
+func LeakInternalPrefixFromContainer(cont *container.Container) *LeakInternalPrefix {
+	return LeakInternalPrefixFromContainerList(cont, 0)
+}
+
+func LeakInternalPrefixListFromContainer(cont *container.Container) []*LeakInternalPrefix {
+	length, _ := strconv.Atoi(G(cont, "totalCount"))
+	arr := make([]*LeakInternalPrefix, length)
+
+	for i := 0; i < length; i++ {
+		arr[i] = LeakInternalPrefixFromContainerList(cont, i)
+	}
+
+	return arr
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -4,7 +4,7 @@ github.com/agext/levenshtein
 github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/ciscoecosystem/aci-go-client v1.53.2
+# github.com/ciscoecosystem/aci-go-client v1.54.0
 github.com/ciscoecosystem/aci-go-client/client
 github.com/ciscoecosystem/aci-go-client/container
 github.com/ciscoecosystem/aci-go-client/models

--- a/website/docs/d/cloud_vrf_leak_routes.html.markdown
+++ b/website/docs/d/cloud_vrf_leak_routes.html.markdown
@@ -1,15 +1,15 @@
 ---
-subcategory: "Networking"
+subcategory: "Cloud"
 layout: "aci"
 page_title: "ACI: aci_cloud_vrf_leak_routes"
 sidebar_current: "docs-aci-data-source-cloud_vrf_leak_routes"
 description: |-
-  Data source for Cloud ACI Inter-VRF Leaked Internal Prefix
+  Data source for Cloud ACI Inter-VRF Leaked Routes
 ---
 
 # aci_cloud_vrf_leak_routes #
 
-Data source for Cloud ACI Inter-VRF Leaked Internal Prefix
+Data source for Cloud ACI Inter-VRF Leaked Routes
 
 
 ## API Information ##
@@ -36,8 +36,8 @@ data "aci_cloud_vrf_leak_routes" "cloud_internal_leak_routes" {
 * `vrf_dn` - (Required) Distinguished name of the parent VRF object.
 
 ## Attribute Reference ##
-* `id` - Attribute id set to the Dn of the Inter-VRF Leaked Internal Prefix object.
-* `annotation` - (Optional) Annotation of the Inter-VRF Leaked Internal Prefix object.
-* `name_alias` - (Optional) Name Alias of the Inter-VRF Leaked Internal Prefix object.
-* `leak_to` - (Optional) A block representing the attributes of `Leak Routes` for the Inter-VRF Leaked Internal Prefix object. Type: Block.
-  * `vrf_dn` - Distinguished name of the destination VRF object, which is mapped to the Inter-VRF Leaked Internal Prefix object.
+* `id` - Attribute id set to the Dn of the Inter-VRF Leaked Route object.
+* `annotation` - (Optional) Annotation of the Inter-VRF Leaked Route object.
+* `name_alias` - (Optional) Name Alias of the Inter-VRF Leaked Route object.
+* `leak_to` - (Optional) A block representing the attributes of `Leak Routes` for the Inter-VRF Leaked Route object. Type: Block.
+  * `vrf_dn` - Distinguished name of the destination VRF object, which is mapped to the Inter-VRF Leaked Route object.

--- a/website/docs/d/cloud_vrf_leak_routes.html.markdown
+++ b/website/docs/d/cloud_vrf_leak_routes.html.markdown
@@ -1,0 +1,43 @@
+---
+subcategory: "Networking"
+layout: "aci"
+page_title: "ACI: aci_cloud_vrf_leak_routes"
+sidebar_current: "docs-aci-data-source-cloud_vrf_leak_routes"
+description: |-
+  Data source for Cloud ACI Inter-VRF Leaked Internal Prefix
+---
+
+# aci_cloud_vrf_leak_routes #
+
+Data source for Cloud ACI Inter-VRF Leaked Internal Prefix
+
+
+## API Information ##
+
+* `Class` - leakInternalPrefix
+* `Distinguished Name` - uni/tn-{tenant_name}/ctx-{vrf_name}/leakroutes/leakintprefix-[{ip}]
+
+
+## GUI Information ##
+
+* `Location` - Application Management -> VRFs -> Leak Routes
+
+
+## Example Usage ##
+
+```hcl
+data "aci_cloud_vrf_leak_routes" "cloud_internal_leak_routes" {
+  vrf_dn    = aci_vrf.vrf1.id
+}
+```
+
+## Argument Reference ##
+
+* `vrf_dn` - (Required) Distinguished name of the parent VRF object.
+
+## Attribute Reference ##
+* `id` - Attribute id set to the Dn of the Inter-VRF Leaked Internal Prefix object.
+* `annotation` - (Optional) Annotation of the Inter-VRF Leaked Internal Prefix object.
+* `name_alias` - (Optional) Name Alias of the Inter-VRF Leaked Internal Prefix object.
+* `leak_to` - (Optional) A block representing the attributes of `Leak Routes` for the Inter-VRF Leaked Internal Prefix object. Type: Block.
+  * `vrf_dn` - Distinguished name of the destination VRF object, which is mapped to the Inter-VRF Leaked Internal Prefix object.

--- a/website/docs/d/vrf_leak_epg_bd_subnet.html.markdown
+++ b/website/docs/d/vrf_leak_epg_bd_subnet.html.markdown
@@ -20,7 +20,7 @@ Data source for ACI Inter-VRF Leaked EPG/BD Subnet
 ## GUI Information ##
 
 * `Location` - Tenants -> Networking -> VRFs -> Inter-VRF Leaked Routes for EPG -> EPG/BD Subnets
-
+* `Location` - Cloud APIC -> Application Management -> VRFs -> Leak Routes
 
 ## Example Usage ##
 

--- a/website/docs/r/cloud_vrf_leak_routes.html.markdown
+++ b/website/docs/r/cloud_vrf_leak_routes.html.markdown
@@ -1,0 +1,55 @@
+---
+subcategory: "Networking"
+layout: "aci"
+page_title: "ACI: aci_cloud_vrf_leak_routes"
+sidebar_current: "docs-aci-resource-cloud_vrf_leak_routes"
+description: |-
+  Manages Cloud ACI Inter-VRF Leaked Internal Prefix
+---
+
+# aci_cloud_vrf_leak_routes #
+
+Manages Cloud ACI Inter-VRF Leaked Internal Prefix
+
+## API Information ##
+
+* `Class` - leakInternalPrefix
+* `Distinguished Name` - uni/tn-{tenant_name}/ctx-{vrf_name}/leakroutes/leakintprefix-[{ip}]
+
+## GUI Information ##
+
+* `Location` - Application Management -> VRFs -> Leak Routes
+
+
+## Example Usage ##
+
+```hcl
+# Only for the Cloud APIC Version >= 25.0
+resource "aci_cloud_vrf_leak_routes" "cloud_internal_leak_routes" {
+  vrf_dn = aci_vrf.src_vrf.id
+  leak_to {
+    vrf_dn = aci_vrf.dst_vrf1.id
+  }
+  leak_to {
+    vrf_dn = aci_vrf.dst_vrf2.id
+  }
+}
+```
+Leak Routes for the Inter-VRF Leaked Internal Prefix
+## Argument Reference ##
+
+* `vrf_dn` - (Required) Distinguished name of the parent VRF object.
+* `annotation` - (Optional) Annotation of the Inter-VRF Leaked Internal Prefix object.
+* `name_alias` - (Optional) Name Alias of the Inter-VRF Leaked Internal Prefix object.
+* `leak_to` - (Optional) A block representing the attributes of `Leak Routes` for the Inter-VRF Leaked Internal Prefix object. Type: Block.
+  * `vrf_dn` - (Required) Distinguished name of the destination VRF object, which is mapped to the Inter-VRF Leaked Internal Prefix object.
+
+## Importing ##
+
+An existing Inter-VRF Leaked Internal Prefix can be [imported][docs-import] into this resource via its Dn, via the following command:
+[docs-import]: https://www.terraform.io/docs/import/index.html
+
+
+```
+terraform import aci_cloud_vrf_leak_routes.example <Dn>
+```

--- a/website/docs/r/cloud_vrf_leak_routes.html.markdown
+++ b/website/docs/r/cloud_vrf_leak_routes.html.markdown
@@ -1,15 +1,15 @@
 ---
-subcategory: "Networking"
+subcategory: "Cloud"
 layout: "aci"
 page_title: "ACI: aci_cloud_vrf_leak_routes"
 sidebar_current: "docs-aci-resource-cloud_vrf_leak_routes"
 description: |-
-  Manages Cloud ACI Inter-VRF Leaked Internal Prefix
+  Manages Cloud ACI Inter-VRF Leaked Routes
 ---
 
 # aci_cloud_vrf_leak_routes #
 
-Manages Cloud ACI Inter-VRF Leaked Internal Prefix
+Manages Cloud ACI Inter-VRF Leaked Routes
 
 ## API Information ##
 
@@ -35,18 +35,18 @@ resource "aci_cloud_vrf_leak_routes" "cloud_internal_leak_routes" {
   }
 }
 ```
-Leak Routes for the Inter-VRF Leaked Internal Prefix
+
 ## Argument Reference ##
 
 * `vrf_dn` - (Required) Distinguished name of the parent VRF object.
-* `annotation` - (Optional) Annotation of the Inter-VRF Leaked Internal Prefix object.
-* `name_alias` - (Optional) Name Alias of the Inter-VRF Leaked Internal Prefix object.
-* `leak_to` - (Optional) A block representing the attributes of `Leak Routes` for the Inter-VRF Leaked Internal Prefix object. Type: Block.
-  * `vrf_dn` - (Required) Distinguished name of the destination VRF object, which is mapped to the Inter-VRF Leaked Internal Prefix object.
+* `annotation` - (Optional) Annotation of the Inter-VRF Leaked Route object.
+* `name_alias` - (Optional) Name Alias of the Inter-VRF Leaked Route object.
+* `leak_to` - (Optional) A block representing the attributes of `Leak Routes` for the Inter-VRF Leaked Route object. Type: Block.
+  * `vrf_dn` - (Required) Distinguished name of the destination VRF object, which is mapped to the Inter-VRF Leaked Route object.
 
 ## Importing ##
 
-An existing Inter-VRF Leaked Internal Prefix can be [imported][docs-import] into this resource via its Dn, via the following command:
+An existing Inter-VRF Leaked Route can be [imported][docs-import] into this resource via its Dn, via the following command:
 [docs-import]: https://www.terraform.io/docs/import/index.html
 
 

--- a/website/docs/r/vrf_leak_epg_bd_subnet.html.markdown
+++ b/website/docs/r/vrf_leak_epg_bd_subnet.html.markdown
@@ -19,9 +19,11 @@ Manages ACI Inter-VRF Leaked EPG/BD Subnet
 ## GUI Information ##
 
 * `Location` - Tenants -> Networking -> VRFs -> Inter-VRF Leaked Routes for EPG -> EPG/BD Subnets
-
+* `Location` - Cloud APIC -> Application Management -> VRFs -> Leak Routes
 
 ## Example Usage ##
+
+Note: `leak_to.*.allow_l3out_advertisement` -  Must be set as true for the Cloud APIC
 
 ```hcl
 resource "aci_vrf_leak_epg_bd_subnet" "vrf_leak_epg_bd_subnet" {
@@ -29,7 +31,7 @@ resource "aci_vrf_leak_epg_bd_subnet" "vrf_leak_epg_bd_subnet" {
   ip                        = "1.1.20.2/24"
   allow_l3out_advertisement = true # true -> public, false -> private, default -> false(private)
   leak_to {
-    vrf_dn                    = data.aci_vrf.default.id
+    vrf_dn = data.aci_vrf.default.id
   }
   leak_to {
     vrf_dn                    = aci_vrf.vrf2.id
@@ -42,11 +44,11 @@ Tenant and VRF destination for Inter-VRF Leaked Routes
 
 * `vrf_dn` - (Required) Distinguished name of the parent VRF object.
 * `ip` - (Required) IP of the Inter-VRF Leaked EPG/BD Subnet object.
-* `annotation` - (Optional) Annotation of the object Inter-VRF Leaked EPG/BD Subnet.
+* `annotation` - (Optional) Annotation of the Inter-VRF Leaked EPG/BD Subnet object.
 * `allow_l3out_advertisement` - (Optional) Visibility of the Inter-VRF Leaked EPG/BD Subnet object. Allowed values are "true", "false" and default value is "false". Type: String.
 * `leak_to` - (Optional) A block representing the attributes of `Tenant and VRF Destinations` for the Inter-VRF Leaked Routes object. Type: Block.
   * `vrf_dn` - (Required) Distinguished name of the destination VRF object, which is mapped to the `Tenant and VRF Destinations` object.
-  * `allow_l3out_advertisement` - (Optional) Scope of the destination VRF object, which is mapped to the `Tenant and VRF Destinations` object. Allowed values are "inherit", "true", "false" and default value is "inherit". Type: String.
+  * `allow_l3out_advertisement` - (Optional) Scope of the destination VRF object, which is mapped to the `Tenant and VRF Destinations` object. Allowed values are "inherit", "true", "false" and default value is "inherit". Only for the Cloud APIC `allow_l3out_advertisement` must be set as `true`. Type: String.
 
 ## Importing ##
 

--- a/website/docs/r/vrf_leak_epg_bd_subnet.html.markdown
+++ b/website/docs/r/vrf_leak_epg_bd_subnet.html.markdown
@@ -23,7 +23,7 @@ Manages ACI Inter-VRF Leaked EPG/BD Subnet
 
 ## Example Usage ##
 
-Note: `leak_to.*.allow_l3out_advertisement` -  Must be set as true for the Cloud APIC
+Note: `leak_to.*.allow_l3out_advertisement` -  Must be set as true for Cloud APIC
 
 ```hcl
 resource "aci_vrf_leak_epg_bd_subnet" "vrf_leak_epg_bd_subnet" {
@@ -48,7 +48,7 @@ Tenant and VRF destination for Inter-VRF Leaked Routes
 * `allow_l3out_advertisement` - (Optional) Visibility of the Inter-VRF Leaked EPG/BD Subnet object. Allowed values are "true", "false" and default value is "false". Type: String.
 * `leak_to` - (Optional) A block representing the attributes of `Tenant and VRF Destinations` for the Inter-VRF Leaked Routes object. Type: Block.
   * `vrf_dn` - (Required) Distinguished name of the destination VRF object, which is mapped to the `Tenant and VRF Destinations` object.
-  * `allow_l3out_advertisement` - (Optional) Scope of the destination VRF object, which is mapped to the `Tenant and VRF Destinations` object. Allowed values are "inherit", "true", "false" and default value is "inherit". Only for the Cloud APIC `allow_l3out_advertisement` must be set as `true`. Type: String.
+  * `allow_l3out_advertisement` - (Optional) Scope of the destination VRF object, which is mapped to the `Tenant and VRF Destinations` object. Allowed values are "inherit", "true", "false" and default value is "inherit". For Cloud APIC allow_l3out_advertisement must be set as true. Type: String.
 
 ## Importing ##
 


### PR DESCRIPTION
Note:

Created resource for the Cloud Leak Routes feature. This feature is only for the Cloud APIC Version >= 25.0.

Leak Routes are divided into two resources:
1. Leak Internal Subnet
2. Leak Internal Prefix