### PR TITLE
Fix intermittent issue with object updates and aci_rest_managed

### DIFF
--- a/aci/resource_aci_rest_managed.go
+++ b/aci/resource_aci_rest_managed.go
@@ -22,7 +22,7 @@ var WriteOnlyAttr = []string{"childAction"}
 var FullClasses = []string{"firmwareFwGrp", "maintMaintGrp", "maintMaintP", "firmwareFwP"}
 
 // List of classes where an immediate GET following a POST might not reflect the created/updated object
-var NoReadClasses = []string{"firmwareFwGrp", "firmwareRsFwgrpp", "fabricNodeBlk"}
+var AllowEmptyReadClasses = []string{"firmwareFwGrp", "firmwareRsFwgrpp", "fabricNodeBlk"}
 
 // List of classes which do not support annotations
 var NoAnnotationClasses = []string{"tagTag"}
@@ -113,7 +113,7 @@ func getAciRestManaged(d *schema.ResourceData, c *container.Container, expectObj
 	restContent, ok := c.Search("imdata", className, "attributes").Index(0).Data().(map[string]interface{})
 
 	if !ok {
-		if expectObject && containsString(NoReadClasses, className) {
+		if expectObject && containsString(AllowEmptyReadClasses, className) {
 			return nil
 		}
 		return diag.Errorf("Failed to retrieve REST payload for class: %s.", className)

--- a/aci/resource_aci_rest_managed.go
+++ b/aci/resource_aci_rest_managed.go
@@ -21,6 +21,9 @@ var WriteOnlyAttr = []string{"childAction"}
 // List of classes where 'rsp-prop-include=config-only' does not return the desired objects/properties
 var FullClasses = []string{"firmwareFwGrp", "maintMaintGrp", "maintMaintP", "firmwareFwP"}
 
+// List of classes where an immediate GET following a POST might not reflect the created/updated object
+var NoReadClasses = []string{"firmwareFwGrp", "firmwareRsFwgrpp", "fabricNodeBlk"}
+
 // List of classes which do not support annotations
 var NoAnnotationClasses = []string{"tagTag"}
 
@@ -99,7 +102,7 @@ func resourceAciRestManaged() *schema.Resource {
 	}
 }
 
-func getAciRestManaged(d *schema.ResourceData, c *container.Container) diag.Diagnostics {
+func getAciRestManaged(d *schema.ResourceData, c *container.Container, expectObject bool) diag.Diagnostics {
 	className := d.Get("class_name").(string)
 	dn := d.Get("dn").(string)
 	d.SetId(dn)
@@ -110,6 +113,9 @@ func getAciRestManaged(d *schema.ResourceData, c *container.Container) diag.Diag
 	restContent, ok := c.Search("imdata", className, "attributes").Index(0).Data().(map[string]interface{})
 
 	if !ok {
+		if expectObject && containsString(NoReadClasses, className) {
+			return nil
+		}
 		return diag.Errorf("Failed to retrieve REST payload for class: %s.", className)
 	}
 
@@ -181,7 +187,7 @@ func resourceAciRestManagedReadHelper(ctx context.Context, d *schema.ResourceDat
 		return nil
 	}
 
-	diags = getAciRestManaged(d, cont)
+	diags = getAciRestManaged(d, cont, expectObject)
 	if diags.HasError() {
 		return diags
 	}


### PR DESCRIPTION
There are some objects where an immediate GET following a POST does not yet reflect the updated state. This fix accepts an empty response to a GET immediately after a POST for the following objects:

- firmwareFwGrp
- firmwareRsFwgrpp
- fabricNodeBlk