### PR TITLE
Fix rest managed resource for pkiExportEncryptionKey class

### DIFF
--- a/aci/resource_aci_rest_managed.go
+++ b/aci/resource_aci_rest_managed.go
@@ -19,7 +19,7 @@ var IgnoreAttr = []string{"extMngdBy", "lcOwn", "modTs", "monPolDn", "uid", "dn"
 var WriteOnlyAttr = []string{"childAction"}
 
 // List of classes where 'rsp-prop-include=config-only' does not return the desired objects/properties
-var FullClasses = []string{"firmwareFwGrp", "maintMaintGrp", "maintMaintP", "firmwareFwP"}
+var FullClasses = []string{"firmwareFwGrp", "maintMaintGrp", "maintMaintP", "firmwareFwP", "pkiExportEncryptionKey"}
 
 // List of classes which do not support annotations
 var NoAnnotationClasses = []string{"tagTag"}


### PR DESCRIPTION
A GET for `/api/mo/uni/exportcryptkey.json?rsp-prop-include=config-only` does not return anything, therefore we need to get all properties.