### PR TITLE
Fix aci_rest_managed firmware policy empty read issue

### DIFF
--- a/aci/resource_aci_rest_managed.go
+++ b/aci/resource_aci_rest_managed.go
@@ -22,7 +22,7 @@ var WriteOnlyAttr = []string{"childAction"}
 var FullClasses = []string{"firmwareFwGrp", "maintMaintGrp", "maintMaintP", "firmwareFwP", "pkiExportEncryptionKey"}
 
 // List of classes where an immediate GET following a POST might not reflect the created/updated object
-var AllowEmptyReadClasses = []string{"firmwareFwGrp", "firmwareRsFwgrpp", "fabricNodeBlk"}
+var AllowEmptyReadClasses = []string{"firmwareFwGrp", "firmwareRsFwgrpp", "firmwareFwP", "fabricNodeBlk"}
 
 // List of classes which do not support annotations
 var NoAnnotationClasses = []string{"tagTag"}


### PR DESCRIPTION
Add `firmwareFwP` to list of classes allowing empty read responses after updates.