### PR TITLE
[bugfix] Removed Computed:True for relationship attributes in "aci_contract_subject"

### DIFF
--- a/aci/resource_aci_vzsubj.go
+++ b/aci/resource_aci_vzsubj.go
@@ -260,12 +260,10 @@ func resourceAciContractSubject() *schema.Resource {
 
 			"relation_vz_rs_subj_graph_att": &schema.Schema{
 				Type:     schema.TypeString,
-				Computed: true,
 				Optional: true,
 			},
 			"relation_vz_rs_sdwan_pol": &schema.Schema{
 				Type:     schema.TypeString,
-				Computed: true,
 				Optional: true,
 			},
 			"relation_vz_rs_subj_filt_att": &schema.Schema{


### PR DESCRIPTION
When Computed and Optional are set to True for an attribute, that attribute can either be set by the user or it is set during Create based on whatever is automatically configured on the target machine. Due to this behaviour the function (HasChange()) in the Update() section of the code ignores a particular scenario where a computed attribute is changed to null. 