### PR TITLE
[fix] ensure relational attribute relation_infra_rs_dom_p is not remo…

### DIFF
--- a/aci/resource_aci_infraattentityp.go
+++ b/aci/resource_aci_infraattentityp.go
@@ -42,6 +42,7 @@ func resourceAciAttachableAccessEntityProfile() *schema.Resource {
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
+				Computed: true,
 				Set:      schema.HashString,
 			},
 		}),


### PR DESCRIPTION
…ved when not defined in configuration of resource aci_attachable_access_entity_profile