### PR TITLE
Enabled computed to the relational attributes

### DIFF
--- a/aci/resource_aci_l3extinstp.go
+++ b/aci/resource_aci_l3extinstp.go
@@ -126,29 +126,32 @@ func resourceAciExternalNetworkInstanceProfile() *schema.Resource {
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
+				Computed: true,
 				Set:      schema.HashString,
 			},
 			"relation_fv_rs_prov": &schema.Schema{
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
+				Computed: true,
 				Set:      schema.HashString,
 			},
 			"relation_l3ext_rs_l3_inst_p_to_dom_p": &schema.Schema{
-				Type: schema.TypeString,
-
+				Type:       schema.TypeString,
+				Computed:   true,
 				Optional:   true,
 				Deprecated: "relation_l3ext_rs_l3_inst_p_to_dom_p attribute is no longer available",
 			},
 			"relation_l3ext_rs_inst_p_to_nat_mapping_epg": &schema.Schema{
-				Type: schema.TypeString,
-
+				Type:       schema.TypeString,
+				Computed:   true,
 				Optional:   true,
 				Deprecated: "relation_l3ext_rs_inst_p_to_nat_mapping_epg attribute is no longer available",
 			},
 			"relation_fv_rs_cons_if": &schema.Schema{
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
 				Optional: true,
 				Set:      schema.HashString,
 			},
@@ -160,6 +163,7 @@ func resourceAciExternalNetworkInstanceProfile() *schema.Resource {
 			},
 			"relation_l3ext_rs_inst_p_to_profile": &schema.Schema{
 				Type:     schema.TypeSet,
+				Computed: true,
 				Optional: true,
 				MaxItems: 2,
 				Elem: &schema.Resource{
@@ -187,18 +191,21 @@ func resourceAciExternalNetworkInstanceProfile() *schema.Resource {
 			"relation_fv_rs_cons": &schema.Schema{
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
 				Optional: true,
 				Set:      schema.HashString,
 			},
 			"relation_fv_rs_prot_by": &schema.Schema{
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
 				Optional: true,
 				Set:      schema.HashString,
 			},
 			"relation_fv_rs_intra_epg": &schema.Schema{
 				Type:       schema.TypeSet,
 				Elem:       &schema.Schema{Type: schema.TypeString},
+				Computed:   true,
 				Optional:   true,
 				Set:        schema.HashString,
 				Deprecated: "relation_fv_rs_intra_epg attribute is no longer available",


### PR DESCRIPTION
Note:

Enabled computed to the relational attributes in the aci_external_network_instance_profile resource to handle multiple resources managed attribute diffs, PR belongs to: https://github.com/CiscoDevNet/terraform-provider-aci/issues/1055 Point 2.

Sample config to test the issue:
```
data "aci_tenant" "common" {
  name = "common"
}

# VRF Setup
data "aci_vrf" "default_vrf" {
  tenant_dn = data.aci_tenant.common.id
  name      = "default"
}

# Tenant Setup
resource "aci_tenant" "terraform_tenant" {
  name = "TF_Ext_InsP"
}

# L3Outside Domain
resource "aci_l3_outside" "l3_outside" {
  tenant_dn              = aci_tenant.terraform_tenant.id
  name                   = "l3_outside"
  relation_l3ext_rs_ectx = data.aci_vrf.default_vrf.id
}

# Contract Setup
resource "aci_contract" "web_contract" {
  tenant_dn = aci_tenant.terraform_tenant.id
  name      = "web_contract"
}

# Note: if you do not provide relation_fv_rs_prov attribute value, still it will "web_contract" be populated in the state file during second time apply, without highlighting any change.
resource "aci_external_network_instance_profile" "external_epg_2" {
  l3_outside_dn = aci_l3_outside.l3_outside.id
  name          = "external_epg_2"
  # relation_fv_rs_prov = [aci_contract.web_contract.id, "uni/tn-common/brc-default"] # test with multiple contracts
  # relation_fv_rs_prov = ["uni/tn-common/brc-default"] # web_contract should be removed during the update operation
  # relation_fv_rs_prov = [] # delete objects from APIC
}

resource "aci_epg_to_contract" "example_provider" {
  application_epg_dn = aci_external_network_instance_profile.external_epg_2.id
  contract_dn        = aci_contract.web_contract.id
  contract_type      = "provider"
}
```