### PR TITLE
Updated Tenant, App Profile, EPG docs to add import blocks

### DIFF
--- a/website/docs/r/application_epg.html.markdown
+++ b/website/docs/r/application_epg.html.markdown
@@ -98,7 +98,7 @@ terraform import aci_application_epg.example "<Dn>"
 
 Starting in Terraform version 1.5, an existing EPG can be imported using [import blocks](https://developer.hashicorp.com/terraform/language/import) via the following configuration:
 
- ```
+ ```hcl
  import {
     id = "<Dn>"
     to = aci_aci_application_epg.example

--- a/website/docs/r/application_epg.html.markdown
+++ b/website/docs/r/application_epg.html.markdown
@@ -90,14 +90,13 @@ Dn of the Application EPG.
 
 ## Importing
 
-An existing Application EPG can be [imported][docs-import] into this resource via its Dn, via the following command:
-[docs-import]: https://www.terraform.io/docs/import/index.html
+An existing Application EPG can be [imported](https://www.terraform.io/docs/import/index.html) into this resource via its Dn, via the following command:
 
 ```
-terraform import aci_application_epg.example <Dn>
+terraform import aci_application_epg.example "<Dn>"
 ```
 
-Starting in Terraform version 1.5, you can use [import blocks](https://developer.hashicorp.com/terraform/language/import) to import an existing Application EPG via the following configuration:
+Starting in Terraform version 1.5, an existing EPG can be imported using [import blocks](https://developer.hashicorp.com/terraform/language/import) via the following configuration:
 
  ```
  import {

--- a/website/docs/r/application_epg.html.markdown
+++ b/website/docs/r/application_epg.html.markdown
@@ -14,7 +14,7 @@ Manages ACI Application EPG
 ## Example Usage
 
 ```hcl
-resource "aci_application_epg" "fooapplication_epg" {
+resource "aci_application_epg" "example" {
     application_profile_dn  = aci_application_profile.app_profile_for_epg.id
     name  					        = "demo_epg"
     description 			      = "from terraform"

--- a/website/docs/r/application_epg.html.markdown
+++ b/website/docs/r/application_epg.html.markdown
@@ -96,3 +96,12 @@ An existing Application EPG can be [imported][docs-import] into this resource vi
 ```
 terraform import aci_application_epg.example <Dn>
 ```
+
+Starting in Terraform version 1.5, you can use [import blocks](https://developer.hashicorp.com/terraform/language/import) to import an existing Application EPG via the following configuration:
+
+ ```
+ import {
+    id = "<Dn>"
+    to = aci_aci_application_epg.example
+ }
+ ```

--- a/website/docs/r/application_profile.html.markdown
+++ b/website/docs/r/application_profile.html.markdown
@@ -47,10 +47,10 @@ An existing Application Profile can be [imported][docs-import] into this resourc
 [docs-import]: https://www.terraform.io/docs/import/index.html
 
 ```
-terraform import aci_application_profile.example <Dn>
+terraform import aci_application_profile.example "<Dn>"
 ```
 
- Starting in Terraform version 1.5, you can use [import blocks](https://developer.hashicorp.com/terraform/language/import) to import an existing Application Profile via the following configuration:
+Starting in Terraform version 1.5, an existing Application Profile can be imported using [import blocks](https://developer.hashicorp.com/terraform/language/import) via the following configuration:
 
  ```
  import {

--- a/website/docs/r/application_profile.html.markdown
+++ b/website/docs/r/application_profile.html.markdown
@@ -49,3 +49,12 @@ An existing Application Profile can be [imported][docs-import] into this resourc
 ```
 terraform import aci_application_profile.example <Dn>
 ```
+
+ Starting in Terraform version 1.5, you can use [import blocks](https://developer.hashicorp.com/terraform/language/import) to import an existing Application Profile via the following configuration:
+
+ ```
+ import {
+    id = "<Dn>"
+    to = aci_aci_application_profile.example
+ }
+ ```

--- a/website/docs/r/tenant.html.markdown
+++ b/website/docs/r/tenant.html.markdown
@@ -43,10 +43,10 @@ An existing Tenant can be [imported][docs-import] into this resource via its Dn,
 [docs-import]: https://www.terraform.io/docs/import/index.html
 
 ```
-terraform import aci_tenant.example <Dn>
+terraform import aci_tenant.example "<Dn>"
 ```
 
-Starting in Terraform version 1.5, you can use [import blocks](https://developer.hashicorp.com/terraform/language/import) to import an existing Tenant via the following configuration:
+Starting in Terraform version 1.5, an existing Tenant can be imported using [import blocks](https://developer.hashicorp.com/terraform/language/import) via the following configuration:
 
 ```code
 import {

--- a/website/docs/r/tenant.html.markdown
+++ b/website/docs/r/tenant.html.markdown
@@ -45,3 +45,12 @@ An existing Tenant can be [imported][docs-import] into this resource via its Dn,
 ```
 terraform import aci_tenant.example <Dn>
 ```
+
+Starting in Terraform version 1.5, you can use [import blocks](https://developer.hashicorp.com/terraform/language/import) to import an existing Tenant via the following configuration:
+
+```code
+import {
+   id = "<Dn>"
+   to = aci_tenant.example
+}
+```


### PR DESCRIPTION
I have added information on the new import blocks feature under the Importing section for the aci_tenant, application_epg, application_profile html markdown files under website/docs/r. 

If you are OK with this, I will update the other Terraform resource web documentation to also use import blocks under the section on importing.