### PR TITLE
[bugfix] Fix regex match in aci_rest_managed resource to allow matching full dn

### DIFF
--- a/internal/provider/resource_aci_rest_managed.go
+++ b/internal/provider/resource_aci_rest_managed.go
@@ -402,7 +402,7 @@ func setAciRestManagedAttributes(ctx context.Context, diags *diag.Diagnostics, c
 	var paramString string
 	var match bool
 	for _, configOnlyDn := range ConfigOnlyDns {
-		match, _ = regexp.MatchString(fmt.Sprintf("%s[a-zA-Z0-9_.:-]+$[^/]*$", configOnlyDn), data.Dn.ValueString())
+		match, _ = regexp.MatchString(fmt.Sprintf("%s[a-zA-Z0-9_.:-]*$[^/]*$", configOnlyDn), data.Dn.ValueString())
 		if match {
 			break
 		}


### PR DESCRIPTION
Currently the regex match here (https://github.com/CiscoDevNet/terraform-provider-aci/blob/bd278434fe0d365704f2a6abb83a263880824b96/internal/provider/resource_aci_rest_managed.go#L405) does not match "uni/exportcryptkey" [here](https://github.com/CiscoDevNet/terraform-provider-aci/blob/bd278434fe0d365704f2a6abb83a263880824b96/internal/provider/resource_aci_rest_managed.go#L67). This PR fixes the regex to also match if the full DN is provided in the `ConfigOnlyDns` list.