### PR TITLE
[minor_change] Enable escaping of HTML characters in Payload.

### DIFF
--- a/docs/data-sources/rest.md
+++ b/docs/data-sources/rest.md
@@ -62,8 +62,8 @@ data "aci_rest" "tenant_rest_children" {
 
 - `id` - Dishtiguished name of object being managed.
 - `class_name` - Class name of object being managed.
-- `content` - Map of key-value pairs which represents the attributes for the object being managed.
+- `content` - A map of key-value pairs which represents the attributes for the object being managed.
 - `dn` - Distinguished name of object being managed.
 - `children` - Set of children of the object being managed.
 - `children.child_class_name` - Class name of the child of the object being managed.
-- `children.child_content` - Map of key-value pairs which represents the attributes for child of the object being managed.
+- `children.child_content` - A map of key-value pairs which represents the attributes for child of the object being managed.

--- a/docs/data-sources/rest_managed.md
+++ b/docs/data-sources/rest_managed.md
@@ -34,7 +34,6 @@ data "aci_rest_managed" "example" {
 * `id` - (string) The Distinguished Name of the object.
 * `annotation` - (string) Annotation for the class object that is being created. When annotation is provided in content this will take precedence.
 * `content` - (map) Map of key-value pairs those needed to be passed to the Model object as parameters. Make sure the key name matches the name with the object parameter in ACI.
-* `escape_html` - (Boolean) Enable escaping of HTML characters when encoding the JSON payload.
 
 * `child` - (list) A list of child objects.
   * `rn` - (string) The Relative Name of the child object.

--- a/docs/data-sources/rest_managed.md
+++ b/docs/data-sources/rest_managed.md
@@ -33,7 +33,8 @@ data "aci_rest_managed" "example" {
 * `class_name` - (string) Which class object is being created.
 * `id` - (string) The Distinguished Name of the object.
 * `annotation` - (string) Annotation for the class object that is being created. When annotation is provided in content this will take precedence.
-* `content` (map) Map of key-value pairs those needed to be passed to the Model object as parameters. Make sure the key name matches the name with the object parameter in ACI.
+* `content` - (map) Map of key-value pairs those needed to be passed to the Model object as parameters. Make sure the key name matches the name with the object parameter in ACI.
+* `escape_html` - (Boolean) Enable escaping of HTML characters when encoding the JSON payload.
 
 * `child` - (list) A list of child objects.
   * `rn` - (string) The Relative Name of the child object.

--- a/docs/data-sources/rest_managed.md
+++ b/docs/data-sources/rest_managed.md
@@ -33,9 +33,9 @@ data "aci_rest_managed" "example" {
 * `class_name` - (string) Which class object is being created.
 * `id` - (string) The Distinguished Name of the object.
 * `annotation` - (string) Annotation for the class object that is being created. When annotation is provided in content this will take precedence.
-* `content` - (map) Map of key-value pairs those needed to be passed to the Model object as parameters. Make sure the key name matches the name with the object parameter in ACI.
+* `content` - (map) A map of key-value pairs those needed to be passed to the Model object as parameters. Make sure the key name matches the name with the object parameter in ACI.
 
 * `child` - (list) A list of child objects.
   * `rn` - (string) The Relative Name of the child object.
   * `class_name` - (string) Class name of child object.
-  * `content` (map) Map of key-value pairs which represents the attributes for the child object.
+  * `content` - (map) A map of key-value pairs which represents the attributes for the child object.

--- a/docs/resources/rest.md
+++ b/docs/resources/rest.md
@@ -55,7 +55,7 @@ resource "aci_rest" "rest_yaml" {
 
 - `path` - (Required) ACI path where object should be created. Starting with api/node/mo/{parent-dn}(if applicable)/{rn of object}.json
 - `class_name` - (Optional) Which class object is being created. (Make sure there is no colon in the classname )
-- `content` - (Optional) Map of key-value pairs those needed to be passed to the Model object as parameters. Make sure the key name matches the name with the object parameter in ACI.
+- `content` - (Optional) A map of key-value pairs those needed to be passed to the Model object as parameters. Make sure the key name matches the name with the object parameter in ACI.
 - `payload` - (Optional) Freestyle JSON or YAML payload which can directly be passed to the REST endpoint added in path. Either of content or payload is required.
 - `dn` - (Optional) Distinguished name of object being managed.
 

--- a/docs/resources/rest_managed.md
+++ b/docs/resources/rest_managed.md
@@ -81,9 +81,12 @@ resource "aci_rest_managed" "example_tenant_with_child" {
 
 * `annotation` - (string) Annotation for the class object that is being created.
   - Default: `orchestrator:terraform`
-* `content` (map) Map of key-value pairs those needed to be passed to the Model object as parameters. Make sure the key name matches the name with the object parameter in ACI.
+* `content` - (map) Map of key-value pairs those needed to be passed to the Model object as parameters. Make sure the key name matches the name with the object parameter in ACI.
 
   !> The annotation property is not allowed to be set in the content map of the resource.
+
+* `escape_html` - (Boolean) Enable escaping of HTML characters when encoding the JSON payload.
+  - Default: `true`
 
 * `child` - (list) A list of child objects.
 
@@ -94,7 +97,7 @@ resource "aci_rest_managed" "example_tenant_with_child" {
 
   #### Optional ###
 
-  * `content` (map) Map of key-value pairs which represents the attributes for the child object. When annotation is provided in the content of the child it will take precedence over the annotation set at the parent level.
+  * `content` - (map) Map of key-value pairs which represents the attributes for the child object. When annotation is provided in the content of the child it will take precedence over the annotation set at the parent level.
 
 ## Importing ##
 

--- a/docs/resources/rest_managed.md
+++ b/docs/resources/rest_managed.md
@@ -81,7 +81,7 @@ resource "aci_rest_managed" "example_tenant_with_child" {
 
 * `annotation` - (string) Annotation for the class object that is being created.
   - Default: `orchestrator:terraform`
-* `content` - (map) Map of key-value pairs those needed to be passed to the Model object as parameters. Make sure the key name matches the name with the object parameter in ACI.
+* `content` - (map) A map of key-value pairs those needed to be passed to the Model object as parameters. Make sure the key name matches the name with the object parameter in ACI.
 
   !> The annotation property is not allowed to be set in the content map of the resource.
 
@@ -97,7 +97,7 @@ resource "aci_rest_managed" "example_tenant_with_child" {
 
   #### Optional ###
 
-  * `content` - (map) Map of key-value pairs which represents the attributes for the child object. When annotation is provided in the content of the child it will take precedence over the annotation set at the parent level.
+  * `content` - (map) A map of key-value pairs which represents the attributes for the child object. When annotation is provided in the content of the child it will take precedence over the annotation set at the parent level.
 
 ## Importing ##
 

--- a/examples/aci_rest_managed/rest_managed.tf
+++ b/examples/aci_rest_managed/rest_managed.tf
@@ -37,3 +37,18 @@ resource "aci_rest_managed" "fvTenant2" {
     }
   }
 }
+
+resource "aci_rest_managed" "aaaPreLoginBanner" {
+  dn          = "uni/userext/preloginbanner"
+  class_name  = "aaaPreLoginBanner"
+  escape_html = false
+  content = {
+    message = <<-EOT
+<<< WARNING >>>  THE PROGRAMS AND DATA HELD ON THIS SYSTEM
+ARE THE PROPERTY OF, OR LICENCED BY, XXXXXXXX. IF THE COMPANY HAS NOT
+AUTHORISED YOUR ACCESS TO THIS SYSTEM YOU WILL COMMIT A CRIMINAL OFFENCE IF
+YOU DO NOT IMMEDIATELY DISCONNECT. UNAUTHORISED ACCESS IS STRICTLY FORBIDDEN
+AND IS A DISCIPLINARY OFFENCE.
+      EOT
+  }
+}

--- a/internal/provider/data_source_aci_rest_managed.go
+++ b/internal/provider/data_source_aci_rest_managed.go
@@ -60,6 +60,10 @@ func (d *AciRestManagedDataSource) Schema(ctx context.Context, req datasource.Sc
 				Computed:            true,
 				MarkdownDescription: `The annotation of the ACI object.`,
 			},
+			"escape_html": schema.BoolAttribute{
+				Computed:            true,
+				MarkdownDescription: "Enable escaping of HTML characters when encoding the JSON payload.",
+			},
 		},
 		Blocks: map[string]schema.Block{
 			"child": schema.SetNestedBlock{
@@ -119,7 +123,7 @@ func (d *AciRestManagedDataSource) Read(ctx context.Context, req datasource.Read
 		return
 	}
 
-	requestData := DoRestRequest(ctx, &resp.Diagnostics, d.client, fmt.Sprintf("api/mo/%s.json?rsp-subtree=children", data.Dn.ValueString()), "GET", nil)
+	requestData := DoRestRequestEscapeHtml(ctx, &resp.Diagnostics, d.client, fmt.Sprintf("api/mo/%s.json?rsp-subtree=children", data.Dn.ValueString()), "GET", nil, data.EscapeHtml.ValueBool())
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/data_source_aci_rest_managed.go
+++ b/internal/provider/data_source_aci_rest_managed.go
@@ -60,10 +60,6 @@ func (d *AciRestManagedDataSource) Schema(ctx context.Context, req datasource.Sc
 				Computed:            true,
 				MarkdownDescription: `The annotation of the ACI object.`,
 			},
-			"escape_html": schema.BoolAttribute{
-				Computed:            true,
-				MarkdownDescription: "Enable escaping of HTML characters when encoding the JSON payload.",
-			},
 		},
 		Blocks: map[string]schema.Block{
 			"child": schema.SetNestedBlock{
@@ -123,7 +119,7 @@ func (d *AciRestManagedDataSource) Read(ctx context.Context, req datasource.Read
 		return
 	}
 
-	requestData := DoRestRequestEscapeHtml(ctx, &resp.Diagnostics, d.client, fmt.Sprintf("api/mo/%s.json?rsp-subtree=children", data.Dn.ValueString()), "GET", nil, data.EscapeHtml.ValueBool())
+	requestData := DoRestRequest(ctx, &resp.Diagnostics, d.client, fmt.Sprintf("api/mo/%s.json?rsp-subtree=children", data.Dn.ValueString()), "GET", nil)
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/resource_aci_rest_managed_test.go
+++ b/internal/provider/resource_aci_rest_managed_test.go
@@ -77,7 +77,7 @@ func TestAccAciRestManaged_connPref(t *testing.T) {
 	})
 }
 
-func testAccAciRestManaged_escapeHtml(t *testing.T) {
+func TestAccAciRestManaged_escapeHtml(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -85,11 +85,11 @@ func testAccAciRestManaged_escapeHtml(t *testing.T) {
 			{
 				Config: testAccAciRestManagedConfig_escapeHtml(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aci_rest_managed.testConnPref", "content.message", "<<< WARNING >>>  VERIFYING THE CONVERSION OF HTML CHARACTERS."),
-					resource.TestCheckResourceAttr("aci_rest_managed.testConnPref", "escape_html", "false"),
-					resource.TestCheckResourceAttr("aci_rest_managed.testConnPref", "dn", "uni/userext/preloginbanner"),
-					resource.TestCheckResourceAttr("aci_rest_managed.testConnPref", "annotation", "orchestrator:terraform"),
-					resource.TestCheckResourceAttr("aci_rest_managed.testConnPref", "class_name", "aaaPreLoginBanner"),
+					resource.TestCheckResourceAttr("aci_rest_managed.aaaPreLoginBanner", "content.message", "<<< WARNING >>>  VERIFYING THE CONVERSION OF HTML CHARACTERS."),
+					resource.TestCheckResourceAttr("aci_rest_managed.aaaPreLoginBanner", "escape_html", "false"),
+					resource.TestCheckResourceAttr("aci_rest_managed.aaaPreLoginBanner", "dn", "uni/userext/preloginbanner"),
+					resource.TestCheckResourceAttr("aci_rest_managed.aaaPreLoginBanner", "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr("aci_rest_managed.aaaPreLoginBanner", "class_name", "aaaPreLoginBanner"),
 				),
 			},
 		},
@@ -1102,9 +1102,7 @@ func testAccAciRestManagedConfig_escapeHtml() string {
 		class_name  = "aaaPreLoginBanner"
 		escape_html = false
 		content = {
-			message = <<-EOT
-		<<< WARNING >>>  VERIFYING THE CONVERSION OF HTML CHARACTERS.
-			EOT
+			message = "<<< WARNING >>>  VERIFYING THE CONVERSION OF HTML CHARACTERS."
 		}
 	}
 	`

--- a/internal/provider/resource_aci_rest_managed_test.go
+++ b/internal/provider/resource_aci_rest_managed_test.go
@@ -77,6 +77,25 @@ func TestAccAciRestManaged_connPref(t *testing.T) {
 	})
 }
 
+func testAccAciRestManaged_escapeHtml(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAciRestManagedConfig_escapeHtml(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aci_rest_managed.testConnPref", "content.message", "<<< WARNING >>>  VERIFYING THE CONVERSION OF HTML CHARACTERS."),
+					resource.TestCheckResourceAttr("aci_rest_managed.testConnPref", "escape_html", "false"),
+					resource.TestCheckResourceAttr("aci_rest_managed.testConnPref", "dn", "uni/userext/preloginbanner"),
+					resource.TestCheckResourceAttr("aci_rest_managed.testConnPref", "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr("aci_rest_managed.testConnPref", "class_name", "aaaPreLoginBanner"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAciRestManaged_noContent(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -1074,4 +1093,19 @@ func testAccAciRestManagedConfig_notDefined(name string) string {
 		}
 	}
 	`, name)
+}
+
+func testAccAciRestManagedConfig_escapeHtml() string {
+	return `
+	resource "aci_rest_managed" "aaaPreLoginBanner" {
+		dn          = "uni/userext/preloginbanner"
+		class_name  = "aaaPreLoginBanner"
+		escape_html = false
+		content = {
+			message = <<-EOT
+		<<< WARNING >>>  VERIFYING THE CONVERSION OF HTML CHARACTERS.
+			EOT
+		}
+	}
+	`
 }


### PR DESCRIPTION
fix #1181 
This change enables escaping of HTML characters '<' and '>' when encoding the JSON payload.
- DoRestRequest() in utils.go accepts an additional boolean parameter escapeHtml by default it is true ('<' -> '\u003c')
- escapeHtml when set to false calls MakeRestRequestRaw(), which will retain the HTML charecters as is it '<' -> '<' 
