### PR TITLE
[bugfix] Prevent error by setting flood_on_encap and prio for aci_end…

### DIFF
--- a/aci/data_source_aci_fvesg.go
+++ b/aci/data_source_aci_fvesg.go
@@ -20,17 +20,10 @@ func dataSourceAciEndpointSecurityGroup() *schema.Resource {
 			},
 			"annotation": {
 				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"flood_on_encap": {
-				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"match_t": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"name": {
@@ -39,17 +32,10 @@ func dataSourceAciEndpointSecurityGroup() *schema.Resource {
 			},
 			"pc_enf_pref": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"pref_gr_memb": {
 				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"prio": {
-				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 		})),

--- a/aci/resource_aci_fvesg.go
+++ b/aci/resource_aci_fvesg.go
@@ -206,13 +206,11 @@ func setEndpointSecurityGroupAttributes(fvESg *models.EndpointSecurityGroup, d *
 		return d, err
 	}
 	d.Set("annotation", fvESgMap["annotation"])
-	d.Set("flood_on_encap", fvESgMap["floodOnEncap"])
 	d.Set("match_t", fvESgMap["matchT"])
 	d.Set("name", fvESgMap["name"])
 	d.Set("application_profile_dn", GetParentDn(fvESg.DistinguishedName, fmt.Sprintf("/esg-%s", fvESgMap["name"])))
 	d.Set("pc_enf_pref", fvESgMap["pcEnfPref"])
 	d.Set("pref_gr_memb", fvESgMap["prefGrMemb"])
-	d.Set("prio", fvESgMap["prio"])
 	d.Set("name_alias", fvESgMap["nameAlias"])
 	return d, nil
 }
@@ -251,10 +249,6 @@ func resourceAciEndpointSecurityGroupCreate(ctx context.Context, d *schema.Resou
 		fvESgAttr.Annotation = "{}"
 	}
 
-	if FloodOnEncap, ok := d.GetOk("flood_on_encap"); ok {
-		fvESgAttr.FloodOnEncap = FloodOnEncap.(string)
-	}
-
 	if MatchT, ok := d.GetOk("match_t"); ok {
 		fvESgAttr.MatchT = MatchT.(string)
 	}
@@ -271,9 +265,6 @@ func resourceAciEndpointSecurityGroupCreate(ctx context.Context, d *schema.Resou
 		fvESgAttr.PrefGrMemb = PrefGrMemb.(string)
 	}
 
-	if Prio, ok := d.GetOk("prio"); ok {
-		fvESgAttr.Prio = Prio.(string)
-	}
 	fvESg := models.NewEndpointSecurityGroup(fmt.Sprintf("esg-%s", name), ApplicationProfileDn, desc, nameAlias, fvESgAttr)
 
 	err := aciClient.Save(fvESg)
@@ -450,10 +441,6 @@ func resourceAciEndpointSecurityGroupUpdate(ctx context.Context, d *schema.Resou
 		fvESgAttr.Annotation = "{}"
 	}
 
-	if FloodOnEncap, ok := d.GetOk("flood_on_encap"); ok {
-		fvESgAttr.FloodOnEncap = FloodOnEncap.(string)
-	}
-
 	if MatchT, ok := d.GetOk("match_t"); ok {
 		fvESgAttr.MatchT = MatchT.(string)
 	}
@@ -470,9 +457,6 @@ func resourceAciEndpointSecurityGroupUpdate(ctx context.Context, d *schema.Resou
 		fvESgAttr.PrefGrMemb = PrefGrMemb.(string)
 	}
 
-	if Prio, ok := d.GetOk("prio"); ok {
-		fvESgAttr.Prio = Prio.(string)
-	}
 	fvESg := models.NewEndpointSecurityGroup(fmt.Sprintf("esg-%s", name), ApplicationProfileDn, desc, nameAlias, fvESgAttr)
 
 	fvESg.Status = "modified"

--- a/docs/data-sources/endpoint_security_group.md
+++ b/docs/data-sources/endpoint_security_group.md
@@ -32,18 +32,14 @@ data "aci_endpoint_security_group" "example" {
 ## Argument Reference ##
 
 * `application_profile_dn` - (Required) Distinguished name of parent Application Profile object.
-* `name` - (Required) name of object Endpoint Security Group.
+* `name` - (Required) Name of object Endpoint Security Group.
 
 ## Attribute Reference ##
 
 * `id` - Attribute id set to the Dn of the Endpoint Security Group.
-* `annotation` - (Optional) Annotation of object Endpoint Security Group.
-* `description` - (Optional) Description of object Endpoint Security Group.
-* `name_alias` - (Optional) Name Alias of object Endpoint Security Group.
-* `flood_on_encap` - (Optional) Handles L2 Multicast/Broadcast and Link-Layer traffic at EPG level. It represents Control at EPG level and decides if the traffic L2 Multicast/Broadcast and Link Local Layer should be flooded only on ENCAP, or based on bridge-domain settings.
-* `match_t` - (Optional) The provider label match criteria.
-* `pc_enf_pref` - (Optional) The preferred policy control.
-* `pref_gr_memb` - (Optional) Represents parameter used to determine
-                    if EPg is part of a group that does not
-                    a contract for communication.
-* `prio` - (Optional) The QoS priority class identifier.
+* `annotation` - (Read-Only) Annotation of object Endpoint Security Group.
+* `description` - (Read-Only) Description of object Endpoint Security Group.
+* `name_alias` - (Read-Only) Name Alias of object Endpoint Security Group.
+* `match_t` - (Read-Only) The provider label match criteria.
+* `pc_enf_pref` - (Read-Only) The preferred policy control.
+* `pref_gr_memb` - (Read-Only) Represents parameter used to determine if EPg is part of a group that does not a contract for communication.

--- a/docs/data-sources/endpoint_security_group.md
+++ b/docs/data-sources/endpoint_security_group.md
@@ -32,14 +32,14 @@ data "aci_endpoint_security_group" "example" {
 ## Argument Reference ##
 
 * `application_profile_dn` - (Required) Distinguished name of parent Application Profile object.
-* `name` - (Required) Name of object Endpoint Security Group.
+* `name` - (Required) Name of the object Endpoint Security Group.
 
 ## Attribute Reference ##
 
 * `id` - Attribute id set to the Dn of the Endpoint Security Group.
-* `annotation` - (Read-Only) Annotation of object Endpoint Security Group.
-* `description` - (Read-Only) Description of object Endpoint Security Group.
-* `name_alias` - (Read-Only) Name Alias of object Endpoint Security Group.
+* `annotation` - (Read-Only) Annotation of the object Endpoint Security Group.
+* `description` - (Read-Only) Description of the object Endpoint Security Group.
+* `name_alias` - (Read-Only) Name Alias of the object Endpoint Security Group.
 * `match_t` - (Read-Only) The provider label match criteria.
 * `pc_enf_pref` - (Read-Only) The preferred policy control.
-* `pref_gr_memb` - (Read-Only) Represents parameter used to determine if EPg is part of a group that does not a contract for communication.
+* `pref_gr_memb` - (Read-Only) Represents parameter used to determine if EPG is part of a group that does not a contract for communication.

--- a/legacy-docs/docs/d/endpoint_security_group.html.markdown
+++ b/legacy-docs/docs/d/endpoint_security_group.html.markdown
@@ -32,18 +32,14 @@ data "aci_endpoint_security_group" "example" {
 ## Argument Reference ##
 
 * `application_profile_dn` - (Required) Distinguished name of parent Application Profile object.
-* `name` - (Required) name of object Endpoint Security Group.
+* `name` - (Required) Name of object Endpoint Security Group.
 
 ## Attribute Reference ##
 
 * `id` - Attribute id set to the Dn of the Endpoint Security Group.
-* `annotation` - (Optional) Annotation of object Endpoint Security Group.
-* `description` - (Optional) Description of object Endpoint Security Group.
-* `name_alias` - (Optional) Name Alias of object Endpoint Security Group.
-* `flood_on_encap` - (Optional) Handles L2 Multicast/Broadcast and Link-Layer traffic at EPG level. It represents Control at EPG level and decides if the traffic L2 Multicast/Broadcast and Link Local Layer should be flooded only on ENCAP, or based on bridge-domain settings.
-* `match_t` - (Optional) The provider label match criteria.
-* `pc_enf_pref` - (Optional) The preferred policy control.
-* `pref_gr_memb` - (Optional) Represents parameter used to determine
-                    if EPg is part of a group that does not
-                    a contract for communication.
-* `prio` - (Optional) The QoS priority class identifier.
+* `annotation` - (Read-Only) Annotation of object Endpoint Security Group.
+* `description` - (Read-Only) Description of object Endpoint Security Group.
+* `name_alias` - (Read-Only) Name Alias of object Endpoint Security Group.
+* `match_t` - (Read-Only) The provider label match criteria.
+* `pc_enf_pref` - (Read-Only) The preferred policy control.
+* `pref_gr_memb` - (Read-Only) Represents parameter used to determine if EPg is part of a group that does not a contract for communication.

--- a/legacy-docs/docs/d/endpoint_security_group.html.markdown
+++ b/legacy-docs/docs/d/endpoint_security_group.html.markdown
@@ -32,14 +32,14 @@ data "aci_endpoint_security_group" "example" {
 ## Argument Reference ##
 
 * `application_profile_dn` - (Required) Distinguished name of parent Application Profile object.
-* `name` - (Required) Name of object Endpoint Security Group.
+* `name` - (Required) Name of the object Endpoint Security Group.
 
 ## Attribute Reference ##
 
 * `id` - Attribute id set to the Dn of the Endpoint Security Group.
-* `annotation` - (Read-Only) Annotation of object Endpoint Security Group.
-* `description` - (Read-Only) Description of object Endpoint Security Group.
-* `name_alias` - (Read-Only) Name Alias of object Endpoint Security Group.
+* `annotation` - (Read-Only) Annotation of the object Endpoint Security Group.
+* `description` - (Read-Only) Description of the object Endpoint Security Group.
+* `name_alias` - (Read-Only) Name Alias of the object Endpoint Security Group.
 * `match_t` - (Read-Only) The provider label match criteria.
 * `pc_enf_pref` - (Read-Only) The preferred policy control.
-* `pref_gr_memb` - (Read-Only) Represents parameter used to determine if EPg is part of a group that does not a contract for communication.
+* `pref_gr_memb` - (Read-Only) Represents parameter used to determine if EPG is part of a group that does not a contract for communication.


### PR DESCRIPTION
…point_security_group

In https://github.com/CiscoDevNet/terraform-provider-aci/commit/f305774eded80334087acd613c634dda068de9a2 `flood_on_encap` and `prio` were removed from schema however in the import/create/update these values were still set. 

Which led to the following error: 

│ Error: Plugin did not respond
│ 
│ The plugin encountered an error, and failed to respond to the plugin6.(*GRPCProvider).ImportResourceState call. The plugin
│ logs may contain more details.
╵


Stack trace from the terraform-provider-aci plugin:

panic: Invalid address to set: []string{"prio"}

Cleaning up the attributes setting from the functions cleaned up the error.