### PR TITLE
Deprecate relation_vz_rs_graph_at from aci_contract

### DIFF
--- a/aci/resource_aci_vzbrcp.go
+++ b/aci/resource_aci_vzbrcp.go
@@ -104,9 +104,9 @@ func resourceAciContract() *schema.Resource {
 			},
 
 			"relation_vz_rs_graph_att": &schema.Schema{
-				Type: schema.TypeString,
-
-				Optional: true,
+				Type:       schema.TypeString,
+				Deprecated: "Use the `relation_vz_rs_subj_graph_att` attribute on `aci_contract_subject` instead.",
+				Optional:   true,
 			},
 
 			"filter": &schema.Schema{
@@ -759,27 +759,12 @@ func resourceAciContractCreate(ctx context.Context, d *schema.ResourceData, m in
 
 	checkDns := make([]string, 0, 1)
 
-	if relationTovzRsGraphAtt, ok := d.GetOk("relation_vz_rs_graph_att"); ok {
-		relationParam := relationTovzRsGraphAtt.(string)
-		checkDns = append(checkDns, relationParam)
-	}
-
 	d.Partial(true)
 	err = checkTDn(aciClient, checkDns)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	d.Partial(false)
-
-	if relationTovzRsGraphAtt, ok := d.GetOk("relation_vz_rs_graph_att"); ok {
-		relationParam := relationTovzRsGraphAtt.(string)
-		relationParamName := GetMOName(relationParam)
-		err = aciClient.CreateRelationvzRsGraphAttFromContract(vzBrCP.DistinguishedName, relationParamName)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-
-	}
 
 	d.SetId(vzBrCP.DistinguishedName)
 	log.Printf("[DEBUG] %s: Creation finished successfully", d.Id())
@@ -970,30 +955,12 @@ func resourceAciContractUpdate(ctx context.Context, d *schema.ResourceData, m in
 
 	checkDns := make([]string, 0, 1)
 
-	if d.HasChange("relation_vz_rs_graph_att") {
-		_, newRelParam := d.GetChange("relation_vz_rs_graph_att")
-		checkDns = append(checkDns, newRelParam.(string))
-	}
-
 	d.Partial(true)
 	err = checkTDn(aciClient, checkDns)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	d.Partial(false)
-
-	if d.HasChange("relation_vz_rs_graph_att") {
-		_, newRelParam := d.GetChange("relation_vz_rs_graph_att")
-		newRelParamName := GetMOName(newRelParam.(string))
-		err = aciClient.DeleteRelationvzRsGraphAttFromContract(vzBrCP.DistinguishedName)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		err = aciClient.CreateRelationvzRsGraphAttFromContract(vzBrCP.DistinguishedName, newRelParamName)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-	}
 
 	d.SetId(vzBrCP.DistinguishedName)
 	log.Printf("[DEBUG] %s: Update finished successfully", d.Id())
@@ -1048,14 +1015,6 @@ func resourceAciContractRead(ctx context.Context, d *schema.ResourceData, m inte
 	if err != nil {
 		d.SetId("")
 		return nil
-	}
-	vzRsGraphAttData, err := aciClient.ReadRelationvzRsGraphAttFromContract(dn)
-	if err != nil {
-		log.Printf("[DEBUG] Error while reading relation vzRsGraphAtt %v", err)
-		d.Set("relation_vz_rs_graph_att", "")
-
-	} else {
-		setRelationAttribute(d, "relation_vz_rs_graph_att", vzRsGraphAttData.(string))
 	}
 
 	log.Printf("[DEBUG] %s: Read finished successfully", d.Id())

--- a/docs/resources/contract.md
+++ b/docs/resources/contract.md
@@ -8,23 +8,38 @@ description: |-
 ---
 
 # aci_contract #
+
 Manages ACI Contract
+
+## API Information ##
+
+* Class: [vzBrCP](https://pubhub.devnetcloud.com/media/model-doc-latest/docs/app/index.html#/objects/vzBrCP/overview)
+
+* Distinguished Name Format: `uni/tn-{name}/brc-{name}`
+
+## GUI Information ##
+
+* Locations:
+  * `Tenants -> Contracts -> Standard`
+  * `Tenants -> Contracts -> Filters`
 
 ## Example Usage ##
 
 ```hcl
-	resource "aci_contract" "foocontract" {
-		tenant_dn   =  aci_tenant.dev_tenant.id
-		description = "From Terraform"
-		name        = "demo_contract"
-		annotation  = "tag_contract"
-		name_alias  = "alias_contract"
-		prio        = "level1"
-		scope       = "tenant"
-		target_dscp = "unspecified"
-	}
+ resource "aci_contract" "foocontract" {
+  tenant_dn   =  aci_tenant.dev_tenant.id
+  description = "From Terraform"
+  name        = "demo_contract"
+  annotation  = "tag_contract"
+  name_alias  = "alias_contract"
+  prio        = "level1"
+  scope       = "tenant"
+  target_dscp = "unspecified"
+ }
 ```
+
 ## Argument Reference ##
+
 * `tenant_dn` - (Required) Distinguished name of parent Tenant object.
 * `name` - (Required) Name of Object contract.
 * `description` - (Optional) Description for object contract.
@@ -65,21 +80,22 @@ Allowed values: "unspecified", "ftpData", "smtp", "dns", "http","pop3", "https",
 Allowed values: "unspecified", "ftpData", "smtp", "dns", "http","pop3", "https", "rtsp"
 * `filter.filter_entry.stateful` - (Optional) Determines if entry is stateful or not. Allowed values are "yes" and "no". Default is "no".
 * `filter.filter_entry.tcp_rules` - (Optional) TCP Session Rules. Allowed values are "unspecified", "est", "syn", "ack", "fin" and "rst". Default is "unspecified".
-* `relation_vz_rs_graph_att` - (Optional) Relation to class vzRsGraphAtt. Cardinality - N_TO_ONE. Type - String.
+* `relation_vz_rs_graph_att` - **Deprecated** (Optional) Relation to class vzRsGraphAtt. Cardinality - N_TO_ONE. Type - String. Use `relation_vz_rs_subj_graph_att` on `aci_contract_subject` instead.
 
-## Attribute Reference
+## Attribute Reference ##
 
 The only attribute that this resource exports is the `id`, which is set to the
 Dn of the Contract.
+
 * `filter.id` - Exports this attribute for filter object. Set to the Dn for the filter managed by the contract.
 * `filter.filter_entry.id` - Exports this attribute for filter entry object of filter object. Set to the Dn for the filter entry managed by the contract.
 
 ## Importing ##
 
 An existing Contract can be [imported][docs-import] into this resource via its Dn, via the following command:
-[docs-import]: https://www.terraform.io/docs/import/index.html
 
-
-```
+```hcl
 terraform import aci_contract.example <Dn>
 ```
+
+[docs-import]: https://www.terraform.io/docs/import/index.html

--- a/legacy-docs/docs/r/contract.html.markdown
+++ b/legacy-docs/docs/r/contract.html.markdown
@@ -8,23 +8,38 @@ description: |-
 ---
 
 # aci_contract #
+
 Manages ACI Contract
+
+## API Information ##
+
+* Class: [vzBrCP](https://pubhub.devnetcloud.com/media/model-doc-latest/docs/app/index.html#/objects/vzBrCP/overview)
+
+* Distinguished Name Format: `uni/tn-{name}/brc-{name}`
+
+## GUI Information ##
+
+* Locations:
+  * `Tenants -> Contracts -> Standard`
+  * `Tenants -> Contracts -> Filters`
 
 ## Example Usage ##
 
 ```hcl
-	resource "aci_contract" "foocontract" {
-		tenant_dn   =  aci_tenant.dev_tenant.id
-		description = "From Terraform"
-		name        = "demo_contract"
-		annotation  = "tag_contract"
-		name_alias  = "alias_contract"
-		prio        = "level1"
-		scope       = "tenant"
-		target_dscp = "unspecified"
-	}
+ resource "aci_contract" "foocontract" {
+  tenant_dn   =  aci_tenant.dev_tenant.id
+  description = "From Terraform"
+  name        = "demo_contract"
+  annotation  = "tag_contract"
+  name_alias  = "alias_contract"
+  prio        = "level1"
+  scope       = "tenant"
+  target_dscp = "unspecified"
+ }
 ```
+
 ## Argument Reference ##
+
 * `tenant_dn` - (Required) Distinguished name of parent Tenant object.
 * `name` - (Required) Name of Object contract.
 * `description` - (Optional) Description for object contract.
@@ -65,21 +80,22 @@ Allowed values: "unspecified", "ftpData", "smtp", "dns", "http","pop3", "https",
 Allowed values: "unspecified", "ftpData", "smtp", "dns", "http","pop3", "https", "rtsp"
 * `filter.filter_entry.stateful` - (Optional) Determines if entry is stateful or not. Allowed values are "yes" and "no". Default is "no".
 * `filter.filter_entry.tcp_rules` - (Optional) TCP Session Rules. Allowed values are "unspecified", "est", "syn", "ack", "fin" and "rst". Default is "unspecified".
-* `relation_vz_rs_graph_att` - (Optional) Relation to class vzRsGraphAtt. Cardinality - N_TO_ONE. Type - String.
+* `relation_vz_rs_graph_att` - **Deprecated** (Optional) Relation to class vzRsGraphAtt. Cardinality - N_TO_ONE. Type - String. Use `relation_vz_rs_subj_graph_att` on `aci_contract_subject` instead.
 
-## Attribute Reference
+## Attribute Reference ##
 
 The only attribute that this resource exports is the `id`, which is set to the
 Dn of the Contract.
+
 * `filter.id` - Exports this attribute for filter object. Set to the Dn for the filter managed by the contract.
 * `filter.filter_entry.id` - Exports this attribute for filter entry object of filter object. Set to the Dn for the filter entry managed by the contract.
 
 ## Importing ##
 
 An existing Contract can be [imported][docs-import] into this resource via its Dn, via the following command:
-[docs-import]: https://www.terraform.io/docs/import/index.html
 
-
-```
+```hcl
 terraform import aci_contract.example <Dn>
 ```
+
+[docs-import]: https://www.terraform.io/docs/import/index.html


### PR DESCRIPTION
Deprecated the non-functional `relation_vz_rs_graph_at` attribute from `aci_contract`. Use `relation_vz_rs_subj_graph_att` on `aci_contract_subject` instead.

Closes #1162 