### PR TITLE
Adding GoReleaser CI Test

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,6 +41,23 @@ jobs:
       - name: Check generated code for diffs
         run: git diff --exit-code
 
+  go-releaser:
+    name: Dry-Run GoReleaser Check
+    needs: [build, diff]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+      - uses: actions/setup-go@v5
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          install-only: true
+          version: latest
+      - name: GoReleaser Release Check
+        run: goreleaser release --skip=publish,sign --snapshot --clean
+
   acceptance:
     name: Acceptance Tests
     if: github.repository_owner == 'CiscoDevNet'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,24 +19,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Unshallow
         run: git fetch --prune --unshallow
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '1.21'
 
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
           args: release --clean


### PR DESCRIPTION
Added a GoReleaser CI test to execute the release process in a dry run mode. This will build the provider in multiple architectures, operating systems and tests the packaging process.
- Also updated the release GitHub action versions.

Closes #1247 