### PR TITLE
[bugfix] Fix to set resource schema version in state to match the pre-migration version when a resource is migrated without attribute changes (DCNE-174)

### DIFF
--- a/gen/definitions/classes.yaml
+++ b/gen/definitions/classes.yaml
@@ -157,6 +157,7 @@ rtctrlProfile:
     - "Tenants -> Networking -> L3Outs -> Route map for import and export Route Control"
     - "Tenants -> Policies -> Protocol -> Route Maps for Route Control"
   sub_category: "L3Out"
+  migration_version: 1
 
 vzOOBBrCP:
   resource_name: "out_of_band_contract"
@@ -252,6 +253,7 @@ tagAnnotation:
     - "Too many DN formats to display, see model documentation for all possible parents of [tagAnnotation](https://pubhub.devnetcloud.com/media/model-doc-latest/docs/app/index.html#/objects/tagAnnotation/overview)."
 
 tagTag:
+  migration_version: 1
   ui_locations:
     - "Under every object as Policy Tags in the Operational tab in recent APIC versions."
   resource_notes:

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -1006,10 +1006,13 @@ func (m *Model) setClassModel(metaPath string, child bool, definitions Definitio
 		}
 	}
 
-	if isMigrationResource(m.PkgName, definitions) {
+	version, changes := isMigrationResource(m.PkgName, definitions)
+	if version {
+		m.SetMigrationVersion(definitions)
+	}
+	if changes {
 		m.SetMigrationClassTypes(definitions)
 		m.SetLegacyChildren(definitions)
-		m.SetMigrationVersion(definitions)
 		m.SetLegacyAttributes(definitions)
 	}
 
@@ -2134,15 +2137,19 @@ func (m *Model) GetOverwriteAttributeMigration(definitions Definitions, attribut
 	return nil
 }
 
-func isMigrationResource(classPkgName string, definitions Definitions) bool {
+func isMigrationResource(classPkgName string, definitions Definitions) (bool, bool) {
+	version := false
+	changes := false
 	if v, ok := definitions.Classes[classPkgName]; ok {
 		for key := range v.(map[interface{}]interface{}) {
 			if key.(string) == "migration_blocks" {
-				return true
+				changes = true
+			} else if key.(string) == "migration_version" {
+				version = true
 			}
 		}
 	}
-	return false
+	return version, changes
 }
 
 // Set variables that are used during the rendering of the example and documentation templates

--- a/gen/templates/resource.go.tmpl
+++ b/gen/templates/resource.go.tmpl
@@ -809,6 +809,8 @@ func (r *{{.ResourceClassName}}Resource) Schema(ctx context.Context, req resourc
 		MarkdownDescription: "The {{.ResourceName}} resource for the '{{.PkgName}}' class",
 		{{- if .LegacyAttributes}}
 		Version: {{add .LegacySchemaVersion 1}},
+		{{- else if .LegacySchemaVersion}}
+		Version: {{.LegacySchemaVersion}},
 		{{- end}}
 
 		Attributes: map[string]schema.Attribute{

--- a/internal/provider/resource_aci_route_control_profile.go
+++ b/internal/provider/resource_aci_route_control_profile.go
@@ -151,6 +151,7 @@ func (r *RtctrlProfileResource) Schema(ctx context.Context, req resource.SchemaR
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
 		MarkdownDescription: "The route_control_profile resource for the 'rtctrlProfile' class",
+		Version:             1,
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/internal/provider/resource_aci_tag.go
+++ b/internal/provider/resource_aci_tag.go
@@ -94,6 +94,7 @@ func (r *TagTagResource) Schema(ctx context.Context, req resource.SchemaRequest,
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
 		MarkdownDescription: "The tag resource for the 'tagTag' class",
+		Version:             1,
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{


### PR DESCRIPTION
fixes #1281 