### PR TITLE
[minor_change] Added certificate_usage property to aci_certificate_authority (DCNE-222)

### DIFF
--- a/docs/data-sources/certificate_authority.md
+++ b/docs/data-sources/certificate_authority.md
@@ -63,6 +63,7 @@ data "aci_certificate_authority" "example_tenant" {
 * `id` - (string) The distinguished name (DN) of the Certificate Authority object.
 * `annotation` (annotation) - (string) The annotation of the Certificate Authority object.
 * `certificate_chain` (certChain) - (string) The PEM-encoded chain of trust from the trustpoint to a trusted root authority.
+* `certificate_usage` (certUsage) - (list) The certificate usage of the Certificate Authority object.
 * `description` (descr) - (string) The description of the Certificate Authority object.
 * `name_alias` (nameAlias) - (string) The name alias of the Certificate Authority object.
 * `owner_key` (ownerKey) - (string) The key for enabling clients to own their data for entity correlation.

--- a/docs/data-sources/certificate_authority.md
+++ b/docs/data-sources/certificate_authority.md
@@ -63,7 +63,7 @@ data "aci_certificate_authority" "example_tenant" {
 * `id` - (string) The distinguished name (DN) of the Certificate Authority object.
 * `annotation` (annotation) - (string) The annotation of the Certificate Authority object.
 * `certificate_chain` (certChain) - (string) The PEM-encoded chain of trust from the trustpoint to a trusted root authority.
-* `certificate_usage` (certUsage) - (list) The certificate usage of the Certificate Authority object.
+* `certificate_usage` (certUsage) - (list) The usage of the Certificate Authority object which can be Web Service/Authentication (WebSvcOrAuth), Platform Experience Grid (pxGrid), or both.
 * `description` (descr) - (string) The description of the Certificate Authority object.
 * `name_alias` (nameAlias) - (string) The name alias of the Certificate Authority object.
 * `owner_key` (ownerKey) - (string) The key for enabling clients to own their data for entity correlation.

--- a/docs/resources/certificate_authority.md
+++ b/docs/resources/certificate_authority.md
@@ -187,7 +187,7 @@ All examples for the Certificate Authority resource can be found in the [example
   - Default: `uni/userext/pkiext`
 * `annotation` (annotation) - (string) The annotation of the Certificate Authority object.
   - Default: `orchestrator:terraform`
-* `certificate_usage` (certUsage) - (list) The certificate usage of the Certificate Authority object.
+* `certificate_usage` (certUsage) - (list) The usage of the Certificate Authority object which can be Web Service/Authentication (WebSvcOrAuth), Platform Experience Grid (pxGrid), or both.
   - Default: `WebSvcOrAuth`.
   - Valid Values: `WebSvcOrAuth`, `pxGrid`.
 * `description` (descr) - (string) The description of the Certificate Authority object.

--- a/docs/resources/certificate_authority.md
+++ b/docs/resources/certificate_authority.md
@@ -105,6 +105,7 @@ hvcNAQELBQADgYEAOmvre+5tgZ0+F3DgsfxNQqLTrGiBgGCIymPkP/cBXXkNuJyl
 KU0Td2OpVyo0eLqjoX5u2G90IBWzhyjFbo+CcKMrSVKj1YOdG0E3OuiJf00=
 -----END CERTIFICATE-----
 EOT
+  certificate_usage = test_value
   description       = "description_1"
   name              = "test_name"
   name_alias        = "name_alias_1"
@@ -144,6 +145,7 @@ hvcNAQELBQADgYEAOmvre+5tgZ0+F3DgsfxNQqLTrGiBgGCIymPkP/cBXXkNuJyl
 KU0Td2OpVyo0eLqjoX5u2G90IBWzhyjFbo+CcKMrSVKj1YOdG0E3OuiJf00=
 -----END CERTIFICATE-----
 EOT
+  certificate_usage = test_value
   description       = "description_1"
   name              = "test_name"
   name_alias        = "name_alias_1"
@@ -185,6 +187,9 @@ All examples for the Certificate Authority resource can be found in the [example
   - Default: `uni/userext/pkiext`
 * `annotation` (annotation) - (string) The annotation of the Certificate Authority object.
   - Default: `orchestrator:terraform`
+* `certificate_usage` (certUsage) - (list) The certificate usage of the Certificate Authority object.
+  - Default: `WebSvcOrAuth`.
+  - Valid Values: `WebSvcOrAuth`, `pxGrid`.
 * `description` (descr) - (string) The description of the Certificate Authority object.
 * `name_alias` (nameAlias) - (string) The name alias of the Certificate Authority object.
 * `owner_key` (ownerKey) - (string) The key for enabling clients to own their data for entity correlation.

--- a/docs/resources/certificate_authority.md
+++ b/docs/resources/certificate_authority.md
@@ -105,7 +105,7 @@ hvcNAQELBQADgYEAOmvre+5tgZ0+F3DgsfxNQqLTrGiBgGCIymPkP/cBXXkNuJyl
 KU0Td2OpVyo0eLqjoX5u2G90IBWzhyjFbo+CcKMrSVKj1YOdG0E3OuiJf00=
 -----END CERTIFICATE-----
 EOT
-  certificate_usage = test_value
+  certificate_usage = ["WebSvcOrAuth"]
   description       = "description_1"
   name              = "test_name"
   name_alias        = "name_alias_1"
@@ -145,7 +145,7 @@ hvcNAQELBQADgYEAOmvre+5tgZ0+F3DgsfxNQqLTrGiBgGCIymPkP/cBXXkNuJyl
 KU0Td2OpVyo0eLqjoX5u2G90IBWzhyjFbo+CcKMrSVKj1YOdG0E3OuiJf00=
 -----END CERTIFICATE-----
 EOT
-  certificate_usage = test_value
+  certificate_usage = ["WebSvcOrAuth"]
   description       = "description_1"
   name              = "test_name"
   name_alias        = "name_alias_1"

--- a/examples/resources/aci_certificate_authority/resource-all-attributes.tf
+++ b/examples/resources/aci_certificate_authority/resource-all-attributes.tf
@@ -17,7 +17,7 @@ hvcNAQELBQADgYEAOmvre+5tgZ0+F3DgsfxNQqLTrGiBgGCIymPkP/cBXXkNuJyl
 KU0Td2OpVyo0eLqjoX5u2G90IBWzhyjFbo+CcKMrSVKj1YOdG0E3OuiJf00=
 -----END CERTIFICATE-----
 EOT
-  certificate_usage = test_value
+  certificate_usage = ["WebSvcOrAuth"]
   description       = "description_1"
   name              = "test_name"
   name_alias        = "name_alias_1"
@@ -57,7 +57,7 @@ hvcNAQELBQADgYEAOmvre+5tgZ0+F3DgsfxNQqLTrGiBgGCIymPkP/cBXXkNuJyl
 KU0Td2OpVyo0eLqjoX5u2G90IBWzhyjFbo+CcKMrSVKj1YOdG0E3OuiJf00=
 -----END CERTIFICATE-----
 EOT
-  certificate_usage = test_value
+  certificate_usage = ["WebSvcOrAuth"]
   description       = "description_1"
   name              = "test_name"
   name_alias        = "name_alias_1"

--- a/examples/resources/aci_certificate_authority/resource-all-attributes.tf
+++ b/examples/resources/aci_certificate_authority/resource-all-attributes.tf
@@ -17,6 +17,7 @@ hvcNAQELBQADgYEAOmvre+5tgZ0+F3DgsfxNQqLTrGiBgGCIymPkP/cBXXkNuJyl
 KU0Td2OpVyo0eLqjoX5u2G90IBWzhyjFbo+CcKMrSVKj1YOdG0E3OuiJf00=
 -----END CERTIFICATE-----
 EOT
+  certificate_usage = test_value
   description       = "description_1"
   name              = "test_name"
   name_alias        = "name_alias_1"
@@ -56,6 +57,7 @@ hvcNAQELBQADgYEAOmvre+5tgZ0+F3DgsfxNQqLTrGiBgGCIymPkP/cBXXkNuJyl
 KU0Td2OpVyo0eLqjoX5u2G90IBWzhyjFbo+CcKMrSVKj1YOdG0E3OuiJf00=
 -----END CERTIFICATE-----
 EOT
+  certificate_usage = test_value
   description       = "description_1"
   name              = "test_name"
   name_alias        = "name_alias_1"

--- a/gen/definitions/properties.yaml
+++ b/gen/definitions/properties.yaml
@@ -198,17 +198,27 @@ pkiTP:
   default_values:
     parent_dn: "uni/userext/pkiext"
   overwrites:
+    cert_usage: "certificate_usage"
     cert_chain: "certificate_chain"
   ignores:
     - "certUsage"
   resource_required:
     - "certChain"
+  ignore_properties_in_test:
+    certUsage: ""
+  documentation:
+    certUsage: "The certificate usage of the Certificate Authority object."
   test_values:
     resource_required: 
       certificate_chain: -----BEGIN CERTIFICATE-----\\nMIICODCCAaGgAwIBAgIJAIt8XMntue0VMA0GCSqGSIb3DQEBCwUAMDQxDjAMBgNV\\nBAMMBUFkbWluMRUwEwYDVQQKDAxZb3VyIENvbXBhbnkxCzAJBgNVBAYTAlVTMCAX\\nDTE4MDEwOTAwNTk0NFoYDzIxMTcxMjE2MDA1OTQ0WjA0MQ4wDAYDVQQDDAVBZG1p\\nbjEVMBMGA1UECgwMWW91ciBDb21wYW55MQswCQYDVQQGEwJVUzCBnzANBgkqhkiG\\n9w0BAQEFAAOBjQAwgYkCgYEAohG/7axtt7CbSaMP7r+2mhTKbNgh0Ww36C7Ta14i\\nv+VmLyKkQHnXinKGhp6uy3Nug+15a+eIu7CrgpBVMQeCiWfsnwRocKcQJWIYDrWl\\nXHxGQn31yYKR6mylE7Dcj3rMFybnyhezr5D8GcP85YRPmwG9H2hO/0Y1FUnWu9Iw\\nAQkCAwEAAaNQME4wHQYDVR0OBBYEFD0jLXfpkrU/ChzRvfruRs/fy1VXMB8GA1Ud\\nIwQYMBaAFD0jLXfpkrU/ChzRvfruRs/fy1VXMAwGA1UdEwQFMAMBAf8wDQYJKoZI\\nhvcNAQELBQADgYEAOmvre+5tgZ0+F3DgsfxNQqLTrGiBgGCIymPkP/cBXXkNuJyl\\n3ac7tArHQc7WEA4U2R2rZbEq8FC3UJJm4nUVtCPvEh3G9OhN2xwYev79yt6pIn/l\\nKU0Td2OpVyo0eLqjoX5u2G90IBWzhyjFbo+CcKMrSVKj1YOdG0E3OuiJf00=\\n-----END CERTIFICATE-----
     default:
+      certificate_usage:
+        - "WebSvcOrAuth"
       certificate_chain: -----BEGIN CERTIFICATE-----\\nMIICODCCAaGgAwIBAgIJAIt8XMntue0VMA0GCSqGSIb3DQEBCwUAMDQxDjAMBgNV\\nBAMMBUFkbWluMRUwEwYDVQQKDAxZb3VyIENvbXBhbnkxCzAJBgNVBAYTAlVTMCAX\\nDTE4MDEwOTAwNTk0NFoYDzIxMTcxMjE2MDA1OTQ0WjA0MQ4wDAYDVQQDDAVBZG1p\\nbjEVMBMGA1UECgwMWW91ciBDb21wYW55MQswCQYDVQQGEwJVUzCBnzANBgkqhkiG\\n9w0BAQEFAAOBjQAwgYkCgYEAohG/7axtt7CbSaMP7r+2mhTKbNgh0Ww36C7Ta14i\\nv+VmLyKkQHnXinKGhp6uy3Nug+15a+eIu7CrgpBVMQeCiWfsnwRocKcQJWIYDrWl\\nXHxGQn31yYKR6mylE7Dcj3rMFybnyhezr5D8GcP85YRPmwG9H2hO/0Y1FUnWu9Iw\\nAQkCAwEAAaNQME4wHQYDVR0OBBYEFD0jLXfpkrU/ChzRvfruRs/fy1VXMB8GA1Ud\\nIwQYMBaAFD0jLXfpkrU/ChzRvfruRs/fy1VXMAwGA1UdEwQFMAMBAf8wDQYJKoZI\\nhvcNAQELBQADgYEAOmvre+5tgZ0+F3DgsfxNQqLTrGiBgGCIymPkP/cBXXkNuJyl\\n3ac7tArHQc7WEA4U2R2rZbEq8FC3UJJm4nUVtCPvEh3G9OhN2xwYev79yt6pIn/l\\nKU0Td2OpVyo0eLqjoX5u2G90IBWzhyjFbo+CcKMrSVKj1YOdG0E3OuiJf00=\\n-----END CERTIFICATE-----
     all:
+      certificate_usage:
+        - "WebSvcOrAuth"
+        - "pxGrid"
       certificate_chain: -----BEGIN CERTIFICATE-----\\nMIICODCCAaGgAwIBAgIJAIt8XMntue0VMA0GCSqGSIb3DQEBCwUAMDQxDjAMBgNV\\nBAMMBUFkbWluMRUwEwYDVQQKDAxZb3VyIENvbXBhbnkxCzAJBgNVBAYTAlVTMCAX\\nDTE4MDEwOTAwNTk0NFoYDzIxMTcxMjE2MDA1OTQ0WjA0MQ4wDAYDVQQDDAVBZG1p\\nbjEVMBMGA1UECgwMWW91ciBDb21wYW55MQswCQYDVQQGEwJVUzCBnzANBgkqhkiG\\n9w0BAQEFAAOBjQAwgYkCgYEAohG/7axtt7CbSaMP7r+2mhTKbNgh0Ww36C7Ta14i\\nv+VmLyKkQHnXinKGhp6uy3Nug+15a+eIu7CrgpBVMQeCiWfsnwRocKcQJWIYDrWl\\nXHxGQn31yYKR6mylE7Dcj3rMFybnyhezr5D8GcP85YRPmwG9H2hO/0Y1FUnWu9Iw\\nAQkCAwEAAaNQME4wHQYDVR0OBBYEFD0jLXfpkrU/ChzRvfruRs/fy1VXMB8GA1Ud\\nIwQYMBaAFD0jLXfpkrU/ChzRvfruRs/fy1VXMAwGA1UdEwQFMAMBAf8wDQYJKoZI\\nhvcNAQELBQADgYEAOmvre+5tgZ0+F3DgsfxNQqLTrGiBgGCIymPkP/cBXXkNuJyl\\n3ac7tArHQc7WEA4U2R2rZbEq8FC3UJJm4nUVtCPvEh3G9OhN2xwYev79yt6pIn/l\\nKU0Td2OpVyo0eLqjoX5u2G90IBWzhyjFbo+CcKMrSVKj1YOdG0E3OuiJf00=\\n-----END CERTIFICATE-----
   
 tagTag:

--- a/gen/definitions/properties.yaml
+++ b/gen/definitions/properties.yaml
@@ -200,12 +200,10 @@ pkiTP:
   overwrites:
     cert_usage: "certificate_usage"
     cert_chain: "certificate_chain"
-  ignores:
-    - "certUsage"
   resource_required:
     - "certChain"
   ignore_properties_in_test:
-    certUsage: ""
+    certUsage: ["WebSvcOrAuth"]
   documentation:
     certUsage: "The certificate usage of the Certificate Authority object."
   test_values:

--- a/gen/definitions/properties.yaml
+++ b/gen/definitions/properties.yaml
@@ -205,7 +205,7 @@ pkiTP:
   ignore_properties_in_test:
     certUsage: ["WebSvcOrAuth"]
   documentation:
-    certUsage: "The certificate usage of the Certificate Authority object."
+    certUsage: "The usage of the Certificate Authority object which can be Web Service/Authentication (WebSvcOrAuth), Platform Experience Grid (pxGrid), or both."
   test_values:
     resource_required: 
       certificate_chain: -----BEGIN CERTIFICATE-----\\nMIICODCCAaGgAwIBAgIJAIt8XMntue0VMA0GCSqGSIb3DQEBCwUAMDQxDjAMBgNV\\nBAMMBUFkbWluMRUwEwYDVQQKDAxZb3VyIENvbXBhbnkxCzAJBgNVBAYTAlVTMCAX\\nDTE4MDEwOTAwNTk0NFoYDzIxMTcxMjE2MDA1OTQ0WjA0MQ4wDAYDVQQDDAVBZG1p\\nbjEVMBMGA1UECgwMWW91ciBDb21wYW55MQswCQYDVQQGEwJVUzCBnzANBgkqhkiG\\n9w0BAQEFAAOBjQAwgYkCgYEAohG/7axtt7CbSaMP7r+2mhTKbNgh0Ww36C7Ta14i\\nv+VmLyKkQHnXinKGhp6uy3Nug+15a+eIu7CrgpBVMQeCiWfsnwRocKcQJWIYDrWl\\nXHxGQn31yYKR6mylE7Dcj3rMFybnyhezr5D8GcP85YRPmwG9H2hO/0Y1FUnWu9Iw\\nAQkCAwEAAaNQME4wHQYDVR0OBBYEFD0jLXfpkrU/ChzRvfruRs/fy1VXMB8GA1Ud\\nIwQYMBaAFD0jLXfpkrU/ChzRvfruRs/fy1VXMAwGA1UdEwQFMAMBAf8wDQYJKoZI\\nhvcNAQELBQADgYEAOmvre+5tgZ0+F3DgsfxNQqLTrGiBgGCIymPkP/cBXXkNuJyl\\n3ac7tArHQc7WEA4U2R2rZbEq8FC3UJJm4nUVtCPvEh3G9OhN2xwYev79yt6pIn/l\\nKU0Td2OpVyo0eLqjoX5u2G90IBWzhyjFbo+CcKMrSVKj1YOdG0E3OuiJf00=\\n-----END CERTIFICATE-----

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -450,7 +450,7 @@ func LookupTestValue(classPkgName, originalPropertyName string, testVars map[str
 					lookupValue = fmt.Sprintf(`"%s"`, val)
 				}
 			case []interface{}:
-				lookupValue = val
+				lookupValue = formatSlice(val)
 			}
 		}
 
@@ -468,7 +468,7 @@ func LookupTestValue(classPkgName, originalPropertyName string, testVars map[str
 								lookupValue = fmt.Sprintf(`"%s"`, val)
 							}
 						case []interface{}:
-							lookupValue = val
+							lookupValue = formatSlice(val)
 						}
 					}
 				}
@@ -1805,7 +1805,12 @@ func ignoreTestProperty(propertyName, classPkgName string, definitions Definitio
 				if key.(string) == "ignore_properties_in_test" {
 					for k, v := range value.(map[interface{}]interface{}) {
 						if k.(string) == propertyName {
-							return true, v.(string)
+							switch val := v.(type) {
+							case []interface{}:
+								return true, formatSlice(val)
+							default:
+								return true, fmt.Sprintf(`"%s"`, val)
+							}
 						}
 					}
 				}
@@ -1813,6 +1818,14 @@ func ignoreTestProperty(propertyName, classPkgName string, definitions Definitio
 		}
 	}
 	return false, ""
+}
+
+func formatSlice(slice []interface{}) string {
+	formattedSlice := make([]string, len(slice))
+	for i, v := range slice {
+		formattedSlice[i] = fmt.Sprintf("\"%v\"", v)
+	}
+	return fmt.Sprintf("[%v]", strings.Join(formattedSlice, ", "))
 }
 
 func updateVersionMismatched(model *Model, classVersion, propertyVersion, propertyName string) {

--- a/gen/meta/pkiTP.json
+++ b/gen/meta/pkiTP.json
@@ -1,911 +1,955 @@
 {
-    "pki:TP": {
-        "contains": {
-            "aaa:RbacAnnotation": "",
-            "fault:Counts": "",
-            "fault:Delegate": "",
-            "fault:Inst": "",
-            "health:Inst": "",
-            "pki:RtClientCertCA": "",
-            "pki:RtSvrCertChain": "",
-            "tag:Annotation": "",
-            "tag:Tag": ""
-        },
-        "rnMap": {
-            "annotationKey-": "tag:Annotation",
-            "fault-": "fault:Inst",
-            "fd-": "fault:Delegate",
-            "fltCnts": "fault:Counts",
-            "health": "health:Inst",
-            "rbacDom-": "aaa:RbacAnnotation",
-            "rtadepgSvrCertChain-": "pki:RtSvrCertChain",
-            "rtcommClientCertCA-": "pki:RtClientCertCA",
-            "tagKey-": "tag:Tag"
-        },
-        "identifiedBy": [
-            "name"
-        ],
-        "rnFormat": "tp-{name}",
-        "containedBy": {
-            "cloud:CertStore": "",
-            "pki:Ep": ""
-        },
-        "superClasses": [
-            "pki:Item",
-            "pki:Definition",
-            "pol:Def",
-            "pol:Obj",
-            "naming:NamedObject"
-        ],
-        "subClasses": {
-
-        },
-        "relationFrom": {
-            "pki:RtClientCertCA": "comm:Https",
-            "pki:RtSvrCertChain": "adepg:ASvr"
-        },
-        "relationTo": {
-
-        },
-        "dnFormats": [
-            "uni/tn-{name}/certstore/tp-{name}",
-            "uni/userext/pkiext/tp-{name}"
-        ],
-        "writeAccess": [
-            "aaa",
-            "admin"
-        ],
-        "readAccess": [
-            "aaa",
-            "admin"
-        ],
-        "faults": {
-            "F4503": "fltPkiTPTPExpired"
-        },
-        "events": {
-            "E4204971": "creation||pki:TP",
-            "E4204972": "deletion||pki:TP",
-            "E4204973": "modification||pki:TP",
-            "E4212896": "creation||pki:TP",
-            "E4212897": "modification||pki:TP",
-            "E4212898": "deletion||pki:TP"
-        },
-        "stats": {
-
-        },
-        "versions": "1.0(1e)-",
-        "isAbstract": false,
-        "isConfigurable": true,
-        "isContextRoot": false,
-        "isNxosConverged": false,
-        "isDeprecated": false,
-        "isHidden": false,
-        "isEncrypted": false,
-        "isExportable": true,
-        "isPersistent": true,
-        "isSubjectToQuota": false,
-        "isObservable": true,
-        "hasStats": false,
-        "isStat": false,
-        "isFaultable": true,
-        "isDomainable": false,
-        "isHealthScorable": true,
-        "shouldCollectHealthStats": false,
-        "healthCollectionSource": "faults",
-        "hasEventRules": false,
-        "abstractionLayer": "ambiguous",
-        "apicNxProcessing": false,
-        "monitoringPolicySource": "Parent",
-        "isCreatableDeletable": "always",
-        "platformFlavors": [
-
-        ],
-        "classId": "1483",
-        "className": "TP",
-        "classPkg": "pki",
-        "featureTag": "",
-        "moCategory": "Regular",
-        "label": "Certificate Authority",
-        "comment": [
-            "A trustpoint (certificate authority/CA), which issues and validates (signs) digital certificates. When participating in secure communications using the public key infrastructure (PKI), a participant can verify the identity of the other party through the CA that signed the other party's public key."
-        ],
-        "properties": {
-            "annotation": {
-                "versions": "3.2(1l)-",
-                "comment": [
-                     "User annotation. Suggested format orchestrator:value"
-                ],
-                "isConfigurable": true,
-                "propGlobalId": "37509",
-                "propLocalId": "8719",
-                "label": "Annotation",
-                "baseType": "string:Basic",
-                "modelType": "mo:Annotation",
-                "needsPropDelimiters": false,
-                "uitype": "string",
-                "createOnly": false,
-                "readWrite": true,
-                "readOnly": false,
-                "isNaming": false,
-                "secure": false,
-                "implicit": false,
-                "mandatory": false,
-                "isOverride": false,
-                "isLike": false,
-                "validators": [
-                     {"min" : 0, "max": 128,
-                         "regexs": [
-                             {"regex" : "^[a-zA-Z0-9_.:-]+$", "type": "include"}
-                         ]
-                     }
-                ],
-                "platformFlavors": [
-
-                ],
-                "isNxosConverged": false,
-                "isDeprecated": false,
-                "isHidden": false
+        "pki:TP": {
+            "contains": {
+                "aaa:RbacAnnotation": "",
+                "fault:Counts": "",
+                "fault:Delegate": "",
+                "fault:Inst": "",
+                "health:Inst": "",
+                "pki:RtClientCertCA": "",
+                "pki:RtSvrCertChain": "",
+                "tag:Annotation": "",
+                "tag:Tag": ""
             },
-            "certChain": {
-                "versions": "1.0(1e)-",
-                "comment": [
-                     "The PEM-encoded chain of trust from the trustpoint to a trusted root authority."
-                ],
-                "isConfigurable": true,
-                "propGlobalId": "1207",
-                "propLocalId": "635",
-                "label": "Certificate Chain",
-                "baseType": "string:CharBuffer",
-                "modelType": "pki:Cert",
-                "needsPropDelimiters": false,
-                "uitype": "string",
-                "createOnly": false,
-                "readWrite": true,
-                "readOnly": false,
-                "isNaming": false,
-                "secure": false,
-                "implicit": false,
-                "mandatory": false,
-                "isOverride": false,
-                "isLike": false,
-                "platformFlavors": [
-
-                ],
-                "isNxosConverged": false,
-                "isDeprecated": false,
-                "isHidden": false
+            "rnMap": {
+                "annotationKey-": "tag:Annotation",
+                "fault-": "fault:Inst",
+                "fd-": "fault:Delegate",
+                "fltCnts": "fault:Counts",
+                "health": "health:Inst",
+                "rbacDom-": "aaa:RbacAnnotation",
+                "rtadepgSvrCertChain-": "pki:RtSvrCertChain",
+                "rtcommClientCertCA-": "pki:RtClientCertCA",
+                "tagKey-": "tag:Tag"
             },
-            "certValidUntil": {
-                "versions": "3.1(1i)-",
-                "comment": [
-                     "The certificate expiration date of the certificate posted by the user in the cert field."
-                ],
-                "isConfigurable": false,
-                "propGlobalId": "35520",
-                "propLocalId": "632",
-                "label": "Certificate Validity",
-                "baseType": "string:CharBuffer",
-                "modelType": "pki:CertValidity",
-                "needsPropDelimiters": false,
-                "uitype": "auto",
-                "createOnly": false,
-                "readWrite": false,
-                "readOnly": true,
-                "isNaming": false,
-                "secure": false,
-                "implicit": true,
-                "mandatory": false,
-                "isOverride": false,
-                "isLike": false,
-                "platformFlavors": [
-
-                ],
-                "isNxosConverged": false,
-                "isDeprecated": false,
-                "isHidden": false
+            "identifiedBy": [
+                "name"
+            ],
+            "rnFormat": "tp-{name}",
+            "containedBy": {
+                "cloud:CertStore": "",
+                "pki:Ep": ""
             },
-            "childAction": {
-                "versions": "1.0(1e)-",
-                "comment": [
-                     "Delete or ignore. For internal use only."
-                ],
-                "isConfigurable": false,
-                "propGlobalId": "4",
-                "propLocalId": "5",
-                "label": "childAction",
-                "baseType": "scalar:Bitmask32",
-                "modelType": "mo:ModificationChildAction",
-                "needsPropDelimiters": false,
-                "uitype": "bitmask",
-                "createOnly": false,
-                "readWrite": false,
-                "readOnly": true,
-                "isNaming": false,
-                "secure": false,
-                "implicit": true,
-                "mandatory": false,
-                "isOverride": false,
-                "isLike": false,
-                "validValues": [
-                     { "value": "16384", "localName": "deleteAll",
-                         "platformFlavors": [
+            "superClasses": [
+                "pki:Item",
+                "pki:Definition",
+                "pol:Def",
+                "pol:Obj",
+                "naming:NamedObject"
+            ],
+            "subClasses": {
 
-                         ],
-                         "label": "Delete All "},
-                     { "value": "8192", "localName": "deleteNonPresent",
-                         "platformFlavors": [
-
-                         ],
-                         "label": "Delete Non Present "},
-                     { "value": "4096", "localName": "ignore",
-                         "platformFlavors": [
-
-                         ],
-                         "label": "Ignore "}
-                ],
-                "platformFlavors": [
-
-                ],
-                "isNxosConverged": false,
-                "isDeprecated": false,
-                "isHidden": false
             },
-            "descr": {
-                "versions": "1.0(1e)-",
-                "comment": [
-                     "Specifies a description of the policy definition."
-                ],
-                "isConfigurable": true,
-                "propGlobalId": "5579",
-                "propLocalId": "28",
-                "label": "Description",
-                "baseType": "string:Basic",
-                "modelType": "naming:Descr",
-                "needsPropDelimiters": false,
-                "uitype": "string",
-                "createOnly": false,
-                "readWrite": true,
-                "readOnly": false,
-                "isNaming": false,
-                "secure": false,
-                "implicit": false,
-                "mandatory": false,
-                "isOverride": false,
-                "isLike": true,
-                "likeProp": "naming:Described:descr",
-                "validators": [
-                     {"min" : 0, "max": 128,
-                         "regexs": [
-                             {"regex" : "^[a-zA-Z0-9\\\\!#$%()*,-./:;@ _{|}~?&+]+$", "type": "include"}
-                         ]
-                     }
-                ],
-                "platformFlavors": [
-
-                ],
-                "isNxosConverged": false,
-                "isDeprecated": false,
-                "isHidden": false
+            "relationFrom": {
+                "pki:RtClientCertCA": "comm:Https",
+                "pki:RtSvrCertChain": "adepg:ASvr"
             },
-            "dn": {
-                "versions": "1.0(1e)-",
-                "comment": [
-                     "A tag or metadata is a non-hierarchical keyword or term assigned to the fabric module."
-                ],
-                "isConfigurable": false,
-                "propGlobalId": "1",
-                "propLocalId": "2",
-                "label": "dn",
-                "baseType": "reference:BinRef",
-                "modelType": "reference:BinRef",
-                "needsPropDelimiters": true,
-                "uitype": "auto",
-                "createOnly": false,
-                "readWrite": false,
-                "readOnly": true,
-                "isNaming": false,
-                "secure": false,
-                "implicit": true,
-                "mandatory": false,
-                "isOverride": false,
-                "isLike": false,
-                "platformFlavors": [
+            "relationTo": {
 
-                ],
-                "isNxosConverged": false,
-                "isDeprecated": false,
-                "isHidden": false
             },
-            "expState": {
-                "versions": "3.1(1i)-",
-                "isConfigurable": false,
-                "propGlobalId": "35521",
-                "propLocalId": "8280",
-                "label": "expState",
-                "baseType": "scalar:Enum8",
-                "modelType": "pki:ExpStatus",
-                "needsPropDelimiters": false,
-                "uitype": "enum",
-                "createOnly": false,
-                "readWrite": false,
-                "readOnly": true,
-                "isNaming": false,
-                "secure": false,
-                "implicit": true,
-                "mandatory": false,
-                "isOverride": false,
-                "isLike": false,
-                "validValues": [
-                     { "value": "1", "localName": "active",
-                         "platformFlavors": [
-
-                         ],
-                         "label": "Active "},
-                     { "value": "active", "localName": "defaultValue",
-                         "platformFlavors": [
-
-                         ],
-                         "label": " "},
-                     { "value": "3", "localName": "expired",
-                         "platformFlavors": [
-
-                         ],
-                         "label": "Expired "},
-                     { "value": "2", "localName": "expiring",
-                         "platformFlavors": [
-
-                         ],
-                         "label": "Expiring "}
-                ],
-                "default": "active",
-                "platformFlavors": [
-
-                ],
-                "isNxosConverged": false,
-                "isDeprecated": false,
-                "isHidden": false
+            "dnFormats": [
+                "uni/tn-{name}/certstore/tp-{name}",
+                "uni/userext/pkiext/tp-{name}"
+            ],
+            "writeAccess": [
+                "aaa",
+                "admin"
+            ],
+            "readAccess": [
+                "aaa",
+                "admin"
+            ],
+            "faults": {
+                "F4503": "fltPkiTPTPExpired",
+                "F4617": "fltPkiTPTPExpiring"
             },
-            "extMngdBy": {
-                "versions": "3.2(1l)-",
-                "comment": [
-                     "Indicates which orchestrator is managing this MO"
-                ],
-                "isConfigurable": false,
-                "propGlobalId": "39648",
-                "propLocalId": "8023",
-                "label": "Managed By",
-                "baseType": "scalar:Bitmask32",
-                "modelType": "mo:ExtMngdByType",
-                "needsPropDelimiters": false,
-                "uitype": "bitmask",
-                "createOnly": false,
-                "readWrite": false,
-                "readOnly": true,
-                "isNaming": false,
-                "secure": false,
-                "implicit": true,
-                "mandatory": false,
-                "isOverride": false,
-                "isLike": false,
-                "validValues": [
-                     { "value": "undefined", "localName": "defaultValue",
-                         "platformFlavors": [
-
-                         ],
-                         "label": " "},
-                     { "value": "1", "localName": "msc",
-                         "platformFlavors": [
-
-                         ],
-                         "label": "MSC "},
-                     { "value": "0", "localName": "undefined",
-                         "platformFlavors": [
-
-                         ],
-                         "label": "Undefined "}
-                ],
-                "default": "undefined",
-                "platformFlavors": [
-
-                ],
-                "isNxosConverged": false,
-                "isDeprecated": false,
-                "isHidden": false
+            "events": {
+                "E4204971": "creation||pki:TP",
+                "E4204972": "deletion||pki:TP",
+                "E4204973": "modification||pki:TP",
+                "E4212896": "creation||pki:TP",
+                "E4212897": "modification||pki:TP",
+                "E4212898": "deletion||pki:TP"
             },
-            "fp": {
-                "versions": "1.0(1e)-",
-                "comment": [
-                     "This property is managed internally and should not be modified by the user."
-                ],
-                "isConfigurable": false,
-                "propGlobalId": "1208",
-                "propLocalId": "636",
-                "label": "fp",
-                "baseType": "string:CharBuffer",
-                "modelType": "pki:FP",
-                "needsPropDelimiters": false,
-                "uitype": "auto",
-                "createOnly": false,
-                "readWrite": false,
-                "readOnly": true,
-                "isNaming": false,
-                "secure": false,
-                "implicit": true,
-                "mandatory": false,
-                "isOverride": false,
-                "isLike": false,
-                "platformFlavors": [
+            "stats": {
 
-                ],
-                "isNxosConverged": false,
-                "isDeprecated": false,
-                "isHidden": false
             },
-            "lcOwn": {
-                "versions": "1.0(1e)-",
-                "comment": [
-                     "A value that indicates how this object was created. For internal use only."
-                ],
-                "isConfigurable": false,
-                "propGlobalId": "9",
-                "propLocalId": "9",
-                "label": "lcOwn",
-                "baseType": "scalar:Enum8",
-                "modelType": "mo:Owner",
-                "needsPropDelimiters": false,
-                "uitype": "enum",
-                "createOnly": false,
-                "readWrite": false,
-                "readOnly": true,
-                "isNaming": false,
-                "secure": false,
-                "implicit": true,
-                "mandatory": false,
-                "isOverride": false,
-                "isLike": false,
-                "validValues": [
-                     { "value": "local", "localName": "defaultValue",
-                         "platformFlavors": [
+            "versions": "1.0(1e)-",
+            "isAbstract": false,
+            "isConfigurable": true,
+            "isContextRoot": false,
+            "isNxosConverged": false,
+            "isDeprecated": false,
+            "isHidden": false,
+            "isEncrypted": false,
+            "isExportable": true,
+            "isPersistent": true,
+            "isSubjectToQuota": false,
+            "isObservable": true,
+            "hasStats": false,
+            "isStat": false,
+            "isFaultable": true,
+            "isDomainable": false,
+            "isHealthScorable": true,
+            "shouldCollectHealthStats": false,
+            "healthCollectionSource": "faults",
+            "hasEventRules": false,
+            "abstractionLayer": "ambiguous",
+            "apicNxProcessing": false,
+            "monitoringPolicySource": "Parent",
+            "isCreatableDeletable": "always",
+            "platformFlavors": [
 
-                         ],
-                         "label": " "},
-                     { "value": "4", "localName": "implicit",
-                         "platformFlavors": [
+            ],
+            "classId": "1483",
+            "className": "TP",
+            "classPkg": "pki",
+            "featureTag": "",
+            "moCategory": "Regular",
+            "label": "Certificate Authority",
+            "comment": [
+                "A trustpoint (certificate authority/CA), which issues and validates (signs) digital certificates. When participating in secure communications using the public key infrastructure (PKI), a participant can verify the identity of the other party through the CA that signed the other party's public key."
+            ],
+            "properties": {
+                "annotation": {
+                    "versions": "3.2(1l)-",
+                    "comment": [
+                         "User annotation. Suggested format orchestrator:value"
+                    ],
+                    "isConfigurable": true,
+                    "propGlobalId": "37509",
+                    "propLocalId": "8719",
+                    "label": "Annotation",
+                    "baseType": "string:Basic",
+                    "modelType": "mo:Annotation",
+                    "needsPropDelimiters": false,
+                    "uitype": "string",
+                    "createOnly": false,
+                    "readWrite": true,
+                    "readOnly": false,
+                    "isNaming": false,
+                    "secure": false,
+                    "implicit": false,
+                    "mandatory": false,
+                    "isOverride": false,
+                    "isLike": false,
+                    "validators": [
+                         {"min" : 0, "max": 128,
+                             "regexs": [
+                                 {"regex" : "^[a-zA-Z0-9_.:-]+$", "type": "include"}
+                             ]
+                         }
+                    ],
+                    "platformFlavors": [
 
-                         ],
-                         "label": "Implicit "},
-                     { "value": "0", "localName": "local",
-                         "platformFlavors": [
+                    ],
+                    "isNxosConverged": false,
+                    "isDeprecated": false,
+                    "isHidden": false
+                },
+                "certChain": {
+                    "versions": "1.0(1e)-",
+                    "comment": [
+                         "The PEM-encoded chain of trust from the trustpoint to a trusted root authority."
+                    ],
+                    "isConfigurable": true,
+                    "propGlobalId": "1207",
+                    "propLocalId": "635",
+                    "label": "Certificate Chain",
+                    "baseType": "string:CharBuffer",
+                    "modelType": "pki:Cert",
+                    "needsPropDelimiters": false,
+                    "uitype": "string",
+                    "createOnly": false,
+                    "readWrite": true,
+                    "readOnly": false,
+                    "isNaming": false,
+                    "secure": false,
+                    "implicit": false,
+                    "mandatory": false,
+                    "isOverride": false,
+                    "isLike": false,
+                    "platformFlavors": [
 
-                         ],
-                         "label": "Local "},
-                     { "value": "1", "localName": "policy",
-                         "platformFlavors": [
+                    ],
+                    "isNxosConverged": false,
+                    "isDeprecated": false,
+                    "isHidden": false
+                },
+                "certUsage": {
+                    "isConfigurable": true,
+                    "propGlobalId": "70961",
+                    "propLocalId": "15548",
+                    "label": "Usage",
+                    "baseType": "scalar:Bitmask16",
+                    "modelType": "pki:CertUsage",
+                    "needsPropDelimiters": false,
+                    "uitype": "bitmask",
+                    "createOnly": true,
+                    "readWrite": false,
+                    "readOnly": false,
+                    "isNaming": false,
+                    "secure": false,
+                    "implicit": false,
+                    "mandatory": false,
+                    "isOverride": false,
+                    "isLike": false,
+                    "validValues": [
+                         { "value": "1", "localName": "WebSvcOrAuth",
+                             "platformFlavors": [
 
-                         ],
-                         "label": "Policy "},
-                     { "value": "2", "localName": "replica",
-                         "platformFlavors": [
+                             ],
+                             "label": "Web Server or Authentication "},
+                         { "value": "WebSvcOrAuth", "localName": "defaultValue",
+                             "platformFlavors": [
 
-                         ],
-                         "label": "Replica "},
-                     { "value": "3", "localName": "resolveOnBehalf",
-                         "platformFlavors": [
+                             ],
+                             "label": " "},
+                         { "value": "2", "localName": "pxGrid",
+                             "platformFlavors": [
 
-                         ],
-                         "label": "Resolved On Behalf "}
-                ],
-                "default": "local",
-                "platformFlavors": [
+                             ],
+                             "label": "pxGrid "}
+                    ],
+                    "default": "WebSvcOrAuth",
+                    "platformFlavors": [
 
-                ],
-                "isNxosConverged": false,
-                "isDeprecated": false,
-                "isHidden": false
-            },
-            "modTs": {
-                "versions": "1.0(1e)-",
-                "comment": [
-                     "The time when this object was last modified."
-                ],
-                "isConfigurable": false,
-                "propGlobalId": "7",
-                "propLocalId": "7",
-                "label": "modTs",
-                "baseType": "scalar:Date",
-                "modelType": "mo:TStamp",
-                "needsPropDelimiters": false,
-                "uitype": "auto",
-                "createOnly": false,
-                "readWrite": false,
-                "readOnly": true,
-                "isNaming": false,
-                "secure": false,
-                "implicit": true,
-                "mandatory": false,
-                "isOverride": false,
-                "isLike": false,
-                "validValues": [
-                     { "value": "never", "localName": "defaultValue",
-                         "platformFlavors": [
+                    ],
+                    "isNxosConverged": false,
+                    "isDeprecated": false,
+                    "isHidden": false
+                },
+                "certValidUntil": {
+                    "versions": "3.1(1i)-",
+                    "comment": [
+                         "The certificate expiration date of the certificate posted by the user in the cert field."
+                    ],
+                    "isConfigurable": false,
+                    "propGlobalId": "35520",
+                    "propLocalId": "632",
+                    "label": "Certificate Validity",
+                    "baseType": "string:CharBuffer",
+                    "modelType": "pki:CertValidity",
+                    "needsPropDelimiters": false,
+                    "uitype": "auto",
+                    "createOnly": false,
+                    "readWrite": false,
+                    "readOnly": true,
+                    "isNaming": false,
+                    "secure": false,
+                    "implicit": true,
+                    "mandatory": false,
+                    "isOverride": false,
+                    "isLike": false,
+                    "platformFlavors": [
 
-                         ],
-                         "label": " "},
-                     { "value": "0", "localName": "never",
-                         "platformFlavors": [
+                    ],
+                    "isNxosConverged": false,
+                    "isDeprecated": false,
+                    "isHidden": false
+                },
+                "childAction": {
+                    "versions": "1.0(1e)-",
+                    "comment": [
+                         "Delete or ignore. For internal use only."
+                    ],
+                    "isConfigurable": false,
+                    "propGlobalId": "4",
+                    "propLocalId": "5",
+                    "label": "childAction",
+                    "baseType": "scalar:Bitmask32",
+                    "modelType": "mo:ModificationChildAction",
+                    "needsPropDelimiters": false,
+                    "uitype": "bitmask",
+                    "createOnly": false,
+                    "readWrite": false,
+                    "readOnly": true,
+                    "isNaming": false,
+                    "secure": false,
+                    "implicit": true,
+                    "mandatory": false,
+                    "isOverride": false,
+                    "isLike": false,
+                    "validValues": [
+                         { "value": "16384", "localName": "deleteAll",
+                             "platformFlavors": [
 
-                         ],
-                         "label": "Never "}
-                ],
-                "default": "never",
-                "platformFlavors": [
+                             ],
+                             "label": "Delete All "},
+                         { "value": "8192", "localName": "deleteNonPresent",
+                             "platformFlavors": [
 
-                ],
-                "isNxosConverged": false,
-                "isDeprecated": false,
-                "isHidden": false
-            },
-            "monPolDn": {
-                "versions": "3.1(1i)-",
-                "comment": [
-                     "The monitoring policy attached to this observable object."
-                ],
-                "isConfigurable": false,
-                "propGlobalId": "26561",
-                "propLocalId": "228",
-                "label": "Monitoring Policy",
-                "baseType": "reference:BinRef",
-                "modelType": "reference:BinRef",
-                "needsPropDelimiters": true,
-                "uitype": "auto",
-                "createOnly": false,
-                "readWrite": false,
-                "readOnly": true,
-                "isNaming": false,
-                "secure": false,
-                "implicit": true,
-                "mandatory": false,
-                "isOverride": false,
-                "isLike": false,
-                "platformFlavors": [
+                             ],
+                             "label": "Delete Non Present "},
+                         { "value": "4096", "localName": "ignore",
+                             "platformFlavors": [
 
-                ],
-                "isNxosConverged": false,
-                "isDeprecated": false,
-                "isHidden": false
-            },
-            "name": {
-                "versions": "1.0(1e)-",
-                "comment": [
-                     "The name of the certificate authority (CA or trustpoint)."
-                ],
-                "isConfigurable": true,
-                "propGlobalId": "7018",
-                "propLocalId": "13",
-                "label": "Name",
-                "baseType": "string:Basic",
-                "modelType": "naming:Name",
-                "needsPropDelimiters": false,
-                "uitype": "string",
-                "createOnly": false,
-                "readWrite": false,
-                "readOnly": false,
-                "isNaming": true,
-                "secure": false,
-                "implicit": false,
-                "mandatory": false,
-                "isOverride": true,
-                "isLike": false,
-                "validators": [
-                     {"min" : 1, "max": 64,
-                         "regexs": [
-                             {"regex" : "^[a-zA-Z0-9_.:-]+$", "type": "include"}
-                         ]
-                     }
-                ],
-                "platformFlavors": [
+                             ],
+                             "label": "Ignore "}
+                    ],
+                    "platformFlavors": [
 
-                ],
-                "isNxosConverged": false,
-                "isDeprecated": false,
-                "isHidden": false
-            },
-            "nameAlias": {
-                "versions": "2.2(1k)-",
-                "isConfigurable": true,
-                "propGlobalId": "28417",
-                "propLocalId": "6719",
-                "label": "Display Name",
-                "baseType": "string:Basic",
-                "modelType": "naming:NameAlias",
-                "needsPropDelimiters": false,
-                "uitype": "string",
-                "createOnly": false,
-                "readWrite": true,
-                "readOnly": false,
-                "isNaming": false,
-                "secure": false,
-                "implicit": false,
-                "mandatory": false,
-                "isOverride": false,
-                "isLike": false,
-                "validators": [
-                     {"min" : 0, "max": 63,
-                         "regexs": [
-                             {"regex" : "^[a-zA-Z0-9_.-]+$", "type": "include"}
-                         ]
-                     }
-                ],
-                "platformFlavors": [
+                    ],
+                    "isNxosConverged": false,
+                    "isDeprecated": false,
+                    "isHidden": false
+                },
+                "descr": {
+                    "versions": "1.0(1e)-",
+                    "comment": [
+                         "Specifies a description of the policy definition."
+                    ],
+                    "isConfigurable": true,
+                    "propGlobalId": "5579",
+                    "propLocalId": "28",
+                    "label": "Description",
+                    "baseType": "string:Basic",
+                    "modelType": "naming:Descr",
+                    "needsPropDelimiters": false,
+                    "uitype": "string",
+                    "createOnly": false,
+                    "readWrite": true,
+                    "readOnly": false,
+                    "isNaming": false,
+                    "secure": false,
+                    "implicit": false,
+                    "mandatory": false,
+                    "isOverride": false,
+                    "isLike": true,
+                    "likeProp": "naming:Described:descr",
+                    "validators": [
+                         {"min" : 0, "max": 128,
+                             "regexs": [
+                                 {"regex" : "^[a-zA-Z0-9\\\\!#$%()*,-./:;@ _{|}~?&+]+$", "type": "include"}
+                             ]
+                         }
+                    ],
+                    "platformFlavors": [
 
-                ],
-                "isNxosConverged": false,
-                "isDeprecated": false,
-                "isHidden": false
-            },
-            "numCerts": {
-                "versions": "1.0(1e)-",
-                "comment": [
-                     "The number of certificates found in the certificate chain."
-                ],
-                "isConfigurable": false,
-                "propGlobalId": "1209",
-                "propLocalId": "637",
-                "label": "numCerts",
-                "baseType": "scalar:Uint32",
-                "modelType": "scalar:Uint32",
-                "needsPropDelimiters": false,
-                "uitype": "auto",
-                "createOnly": false,
-                "readWrite": false,
-                "readOnly": true,
-                "isNaming": false,
-                "secure": false,
-                "implicit": true,
-                "mandatory": false,
-                "isOverride": false,
-                "isLike": false,
-                "validValues": [
-                     { "value": "0", "localName": "defaultValue",
-                         "platformFlavors": [
+                    ],
+                    "isNxosConverged": false,
+                    "isDeprecated": false,
+                    "isHidden": false
+                },
+                "dn": {
+                    "versions": "1.0(1e)-",
+                    "comment": [
+                         "A tag or metadata is a non-hierarchical keyword or term assigned to the fabric module."
+                    ],
+                    "isConfigurable": false,
+                    "propGlobalId": "1",
+                    "propLocalId": "2",
+                    "label": "dn",
+                    "baseType": "reference:BinRef",
+                    "modelType": "reference:BinRef",
+                    "needsPropDelimiters": true,
+                    "uitype": "auto",
+                    "createOnly": false,
+                    "readWrite": false,
+                    "readOnly": true,
+                    "isNaming": false,
+                    "secure": false,
+                    "implicit": true,
+                    "mandatory": false,
+                    "isOverride": false,
+                    "isLike": false,
+                    "platformFlavors": [
 
-                         ],
-                         "label": " "}
-                ],
-                "default": "0",
-                "platformFlavors": [
+                    ],
+                    "isNxosConverged": false,
+                    "isDeprecated": false,
+                    "isHidden": false
+                },
+                "expState": {
+                    "versions": "3.1(1i)-",
+                    "isConfigurable": false,
+                    "propGlobalId": "35521",
+                    "propLocalId": "8280",
+                    "label": "expState",
+                    "baseType": "scalar:Enum8",
+                    "modelType": "pki:ExpStatus",
+                    "needsPropDelimiters": false,
+                    "uitype": "enum",
+                    "createOnly": false,
+                    "readWrite": false,
+                    "readOnly": true,
+                    "isNaming": false,
+                    "secure": false,
+                    "implicit": true,
+                    "mandatory": false,
+                    "isOverride": false,
+                    "isLike": false,
+                    "validValues": [
+                         { "value": "1", "localName": "active",
+                             "platformFlavors": [
 
-                ],
-                "isNxosConverged": false,
-                "isDeprecated": false,
-                "isHidden": false
-            },
-            "ownerKey": {
-                "versions": "1.0(1e)-",
-                "comment": [
-                     "The key for enabling clients to own their data for entity correlation."
-                ],
-                "isConfigurable": true,
-                "propGlobalId": "15230",
-                "propLocalId": "4100",
-                "label": "ownerKey",
-                "baseType": "string:Basic",
-                "modelType": "naming:Descr",
-                "needsPropDelimiters": false,
-                "uitype": "string",
-                "createOnly": false,
-                "readWrite": true,
-                "readOnly": false,
-                "isNaming": false,
-                "secure": false,
-                "implicit": false,
-                "mandatory": false,
-                "isOverride": false,
-                "isLike": false,
-                "validators": [
-                     {"min" : 0, "max": 128,
-                         "regexs": [
-                             {"regex" : "^[a-zA-Z0-9\\\\!#$%()*,-./:;@ _{|}~?&+]+$", "type": "include"}
-                         ]
-                     }
-                ],
-                "platformFlavors": [
+                             ],
+                             "label": "Active "},
+                         { "value": "active", "localName": "defaultValue",
+                             "platformFlavors": [
 
-                ],
-                "isNxosConverged": false,
-                "isDeprecated": false,
-                "isHidden": false
-            },
-            "ownerTag": {
-                "versions": "1.0(1e)-",
-                "comment": [
-                     "A tag for enabling clients to add their own data. For example, to indicate who created this object."
-                ],
-                "isConfigurable": true,
-                "propGlobalId": "15231",
-                "propLocalId": "4101",
-                "label": "ownerTag",
-                "baseType": "string:Basic",
-                "modelType": "naming:Descr",
-                "needsPropDelimiters": false,
-                "uitype": "string",
-                "createOnly": false,
-                "readWrite": true,
-                "readOnly": false,
-                "isNaming": false,
-                "secure": false,
-                "implicit": false,
-                "mandatory": false,
-                "isOverride": false,
-                "isLike": false,
-                "validators": [
-                     {"min" : 0, "max": 64,
-                         "regexs": [
-                             {"regex" : "^[a-zA-Z0-9\\\\!#$%()*,-./:;@ _{|}~?&+]+$", "type": "include"}
-                         ]
-                     }
-                ],
-                "platformFlavors": [
+                             ],
+                             "label": " "},
+                         { "value": "3", "localName": "expired",
+                             "platformFlavors": [
 
-                ],
-                "isNxosConverged": false,
-                "isDeprecated": false,
-                "isHidden": false
-            },
-            "rn": {
-                "versions": "1.0(1e)-",
-                "comment": [
-                     "Identifies an object from its siblings within the context of its parent object. The distinguished name contains a sequence of relative names."
-                ],
-                "isConfigurable": false,
-                "propGlobalId": "2",
-                "propLocalId": "3",
-                "label": "rn",
-                "baseType": "reference:BinRN",
-                "modelType": "reference:BinRN",
-                "needsPropDelimiters": true,
-                "uitype": "auto",
-                "createOnly": false,
-                "readWrite": false,
-                "readOnly": true,
-                "isNaming": false,
-                "secure": false,
-                "implicit": true,
-                "mandatory": false,
-                "isOverride": false,
-                "isLike": false,
-                "platformFlavors": [
+                             ],
+                             "label": "Expired "},
+                         { "value": "2", "localName": "expiring",
+                             "platformFlavors": [
 
-                ],
-                "isNxosConverged": false,
-                "isDeprecated": false,
-                "isHidden": false
-            },
-            "status": {
-                "versions": "1.0(1e)-",
-                "comment": [
-                     "The upgrade status. This property is for internal use only."
-                ],
-                "isConfigurable": false,
-                "propGlobalId": "3",
-                "propLocalId": "4",
-                "label": "status",
-                "baseType": "scalar:Bitmask32",
-                "modelType": "mo:ModificationStatus",
-                "needsPropDelimiters": false,
-                "uitype": "bitmask",
-                "createOnly": false,
-                "readWrite": false,
-                "readOnly": true,
-                "isNaming": false,
-                "secure": false,
-                "implicit": true,
-                "mandatory": false,
-                "isOverride": false,
-                "isLike": false,
-                "validValues": [
-                     { "value": "2", "localName": "created",
-                         "platformFlavors": [
+                             ],
+                             "label": "Expiring "}
+                    ],
+                    "default": "active",
+                    "platformFlavors": [
 
-                         ],
-                         "comment": [
-                             "In a setter method: specifies that an object should be created. An error is returned if the object already exists.  \nIn the return value of a setter method: indicates that an object has been created.  \n"
-                         ],
-                         "label": "Created "},
-                     { "value": "8", "localName": "deleted",
-                         "platformFlavors": [
+                    ],
+                    "isNxosConverged": false,
+                    "isDeprecated": false,
+                    "isHidden": false
+                },
+                "extMngdBy": {
+                    "versions": "3.2(1l)-",
+                    "comment": [
+                         "Indicates which orchestrator is managing this MO"
+                    ],
+                    "isConfigurable": false,
+                    "propGlobalId": "39648",
+                    "propLocalId": "8023",
+                    "label": "Managed By",
+                    "baseType": "scalar:Bitmask32",
+                    "modelType": "mo:ExtMngdByType",
+                    "needsPropDelimiters": false,
+                    "uitype": "bitmask",
+                    "createOnly": false,
+                    "readWrite": false,
+                    "readOnly": true,
+                    "isNaming": false,
+                    "secure": false,
+                    "implicit": true,
+                    "mandatory": false,
+                    "isOverride": false,
+                    "isLike": false,
+                    "validValues": [
+                         { "value": "undefined", "localName": "defaultValue",
+                             "platformFlavors": [
 
-                         ],
-                         "comment": [
-                             "In a setter method: specifies that an object should be deleted.  \nIn the return value of a setter method: indicates that an object has been deleted.\n"
-                         ],
-                         "label": "Deleted "},
-                     { "value": "4", "localName": "modified",
-                         "platformFlavors": [
+                             ],
+                             "label": " "},
+                         { "value": "1", "localName": "msc",
+                             "platformFlavors": [
 
-                         ],
-                         "comment": [
-                             "In a setter method: specifies that an object should be modified  \nIn the return value of a setter method: indicates that an object has been modified.\n"
-                         ],
-                         "label": "Modified "}
-                ],
-                "platformFlavors": [
+                             ],
+                             "label": "MSC "},
+                         { "value": "0", "localName": "undefined",
+                             "platformFlavors": [
 
-                ],
-                "isNxosConverged": false,
-                "isDeprecated": false,
-                "isHidden": false
-            },
-            "uid": {
-                "versions": "1.0(1e)-",
-                "comment": [
-                     "A unique identifier for this object."
-                ],
-                "isConfigurable": false,
-                "propGlobalId": "8",
-                "propLocalId": "8",
-                "label": "uid",
-                "baseType": "scalar:Uint16",
-                "modelType": "scalar:Uint16",
-                "needsPropDelimiters": false,
-                "uitype": "auto",
-                "createOnly": false,
-                "readWrite": false,
-                "readOnly": true,
-                "isNaming": false,
-                "secure": false,
-                "implicit": true,
-                "mandatory": false,
-                "isOverride": false,
-                "isLike": false,
-                "platformFlavors": [
+                             ],
+                             "label": "Undefined "}
+                    ],
+                    "default": "undefined",
+                    "platformFlavors": [
 
-                ],
-                "isNxosConverged": false,
-                "isDeprecated": false,
-                "isHidden": false
-            },
-            "userdom": {
-                "versions": "5.0(1k)-",
-                "isConfigurable": true,
-                "propGlobalId": "60657",
-                "propLocalId": "13244",
-                "label": "userdom",
-                "baseType": "string:Basic",
-                "modelType": "mo:UserDomType",
-                "needsPropDelimiters": false,
-                "uitype": "string",
-                "createOnly": false,
-                "readWrite": true,
-                "readOnly": false,
-                "isNaming": false,
-                "secure": false,
-                "implicit": false,
-                "mandatory": false,
-                "isOverride": false,
-                "isLike": false,
-                "validators": [
-                     {"min" : 0, "max": 1024,
-                         "regexs": [
-                             {"regex" : "^[a-zA-Z0-9_.:-]+$", "type": "include"}
-                         ]
-                     }
-                ],
-                "validValues": [
-                     { "value": "all", "localName": "defaultValue",
-                         "platformFlavors": [
+                    ],
+                    "isNxosConverged": false,
+                    "isDeprecated": false,
+                    "isHidden": false
+                },
+                "fp": {
+                    "versions": "1.0(1e)-",
+                    "comment": [
+                         "This property is managed internally and should not be modified by the user."
+                    ],
+                    "isConfigurable": false,
+                    "propGlobalId": "1208",
+                    "propLocalId": "636",
+                    "label": "fp",
+                    "baseType": "string:CharBuffer",
+                    "modelType": "pki:FP",
+                    "needsPropDelimiters": false,
+                    "uitype": "auto",
+                    "createOnly": false,
+                    "readWrite": false,
+                    "readOnly": true,
+                    "isNaming": false,
+                    "secure": false,
+                    "implicit": true,
+                    "mandatory": false,
+                    "isOverride": false,
+                    "isLike": false,
+                    "platformFlavors": [
 
-                         ],
-                         "label": " "}
-                ],
-                "default": "all",
-                "platformFlavors": [
+                    ],
+                    "isNxosConverged": false,
+                    "isDeprecated": false,
+                    "isHidden": false
+                },
+                "lcOwn": {
+                    "versions": "1.0(1e)-",
+                    "comment": [
+                         "A value that indicates how this object was created. For internal use only."
+                    ],
+                    "isConfigurable": false,
+                    "propGlobalId": "9",
+                    "propLocalId": "9",
+                    "label": "lcOwn",
+                    "baseType": "scalar:Enum8",
+                    "modelType": "mo:Owner",
+                    "needsPropDelimiters": false,
+                    "uitype": "enum",
+                    "createOnly": false,
+                    "readWrite": false,
+                    "readOnly": true,
+                    "isNaming": false,
+                    "secure": false,
+                    "implicit": true,
+                    "mandatory": false,
+                    "isOverride": false,
+                    "isLike": false,
+                    "validValues": [
+                         { "value": "local", "localName": "defaultValue",
+                             "platformFlavors": [
 
-                ],
-                "isNxosConverged": false,
-                "isDeprecated": false,
-                "isHidden": false
+                             ],
+                             "label": " "},
+                         { "value": "4", "localName": "implicit",
+                             "platformFlavors": [
+
+                             ],
+                             "label": "Implicit "},
+                         { "value": "0", "localName": "local",
+                             "platformFlavors": [
+
+                             ],
+                             "label": "Local "},
+                         { "value": "1", "localName": "policy",
+                             "platformFlavors": [
+
+                             ],
+                             "label": "Policy "},
+                         { "value": "2", "localName": "replica",
+                             "platformFlavors": [
+
+                             ],
+                             "label": "Replica "},
+                         { "value": "3", "localName": "resolveOnBehalf",
+                             "platformFlavors": [
+
+                             ],
+                             "label": "Resolved On Behalf "}
+                    ],
+                    "default": "local",
+                    "platformFlavors": [
+
+                    ],
+                    "isNxosConverged": false,
+                    "isDeprecated": false,
+                    "isHidden": false
+                },
+                "modTs": {
+                    "versions": "1.0(1e)-",
+                    "comment": [
+                         "The time when this object was last modified."
+                    ],
+                    "isConfigurable": false,
+                    "propGlobalId": "7",
+                    "propLocalId": "7",
+                    "label": "modTs",
+                    "baseType": "scalar:Date",
+                    "modelType": "mo:TStamp",
+                    "needsPropDelimiters": false,
+                    "uitype": "auto",
+                    "createOnly": false,
+                    "readWrite": false,
+                    "readOnly": true,
+                    "isNaming": false,
+                    "secure": false,
+                    "implicit": true,
+                    "mandatory": false,
+                    "isOverride": false,
+                    "isLike": false,
+                    "validValues": [
+                         { "value": "never", "localName": "defaultValue",
+                             "platformFlavors": [
+
+                             ],
+                             "label": " "},
+                         { "value": "0", "localName": "never",
+                             "platformFlavors": [
+
+                             ],
+                             "label": "Never "}
+                    ],
+                    "default": "never",
+                    "platformFlavors": [
+
+                    ],
+                    "isNxosConverged": false,
+                    "isDeprecated": false,
+                    "isHidden": false
+                },
+                "monPolDn": {
+                    "versions": "3.1(1i)-",
+                    "comment": [
+                         "The monitoring policy attached to this observable object."
+                    ],
+                    "isConfigurable": false,
+                    "propGlobalId": "26561",
+                    "propLocalId": "228",
+                    "label": "Monitoring Policy",
+                    "baseType": "reference:BinRef",
+                    "modelType": "reference:BinRef",
+                    "needsPropDelimiters": true,
+                    "uitype": "auto",
+                    "createOnly": false,
+                    "readWrite": false,
+                    "readOnly": true,
+                    "isNaming": false,
+                    "secure": false,
+                    "implicit": true,
+                    "mandatory": false,
+                    "isOverride": false,
+                    "isLike": false,
+                    "platformFlavors": [
+
+                    ],
+                    "isNxosConverged": false,
+                    "isDeprecated": false,
+                    "isHidden": false
+                },
+                "name": {
+                    "versions": "1.0(1e)-",
+                    "comment": [
+                         "The name of the certificate authority (CA or trustpoint)."
+                    ],
+                    "isConfigurable": true,
+                    "propGlobalId": "7018",
+                    "propLocalId": "13",
+                    "label": "Name",
+                    "baseType": "string:Basic",
+                    "modelType": "naming:Name",
+                    "needsPropDelimiters": false,
+                    "uitype": "string",
+                    "createOnly": false,
+                    "readWrite": false,
+                    "readOnly": false,
+                    "isNaming": true,
+                    "secure": false,
+                    "implicit": false,
+                    "mandatory": false,
+                    "isOverride": true,
+                    "isLike": false,
+                    "validators": [
+                         {"min" : 1, "max": 64,
+                             "regexs": [
+                                 {"regex" : "^[a-zA-Z0-9_.:-]+$", "type": "include"}
+                             ]
+                         }
+                    ],
+                    "platformFlavors": [
+
+                    ],
+                    "isNxosConverged": false,
+                    "isDeprecated": false,
+                    "isHidden": false
+                },
+                "nameAlias": {
+                    "versions": "2.2(1k)-",
+                    "isConfigurable": true,
+                    "propGlobalId": "28417",
+                    "propLocalId": "6719",
+                    "label": "Display Name",
+                    "baseType": "string:Basic",
+                    "modelType": "naming:NameAlias",
+                    "needsPropDelimiters": false,
+                    "uitype": "string",
+                    "createOnly": false,
+                    "readWrite": true,
+                    "readOnly": false,
+                    "isNaming": false,
+                    "secure": false,
+                    "implicit": false,
+                    "mandatory": false,
+                    "isOverride": false,
+                    "isLike": false,
+                    "validators": [
+                         {"min" : 0, "max": 63,
+                             "regexs": [
+                                 {"regex" : "^[a-zA-Z0-9_.-]+$", "type": "include"}
+                             ]
+                         }
+                    ],
+                    "platformFlavors": [
+
+                    ],
+                    "isNxosConverged": false,
+                    "isDeprecated": false,
+                    "isHidden": false
+                },
+                "numCerts": {
+                    "versions": "1.0(1e)-",
+                    "comment": [
+                         "The number of certificates found in the certificate chain."
+                    ],
+                    "isConfigurable": false,
+                    "propGlobalId": "1209",
+                    "propLocalId": "637",
+                    "label": "numCerts",
+                    "baseType": "scalar:Uint32",
+                    "modelType": "scalar:Uint32",
+                    "needsPropDelimiters": false,
+                    "uitype": "auto",
+                    "createOnly": false,
+                    "readWrite": false,
+                    "readOnly": true,
+                    "isNaming": false,
+                    "secure": false,
+                    "implicit": true,
+                    "mandatory": false,
+                    "isOverride": false,
+                    "isLike": false,
+                    "validValues": [
+                         { "value": "0", "localName": "defaultValue",
+                             "platformFlavors": [
+
+                             ],
+                             "label": " "}
+                    ],
+                    "default": "0",
+                    "platformFlavors": [
+
+                    ],
+                    "isNxosConverged": false,
+                    "isDeprecated": false,
+                    "isHidden": false
+                },
+                "ownerKey": {
+                    "versions": "1.0(1e)-",
+                    "comment": [
+                         "The key for enabling clients to own their data for entity correlation."
+                    ],
+                    "isConfigurable": true,
+                    "propGlobalId": "15230",
+                    "propLocalId": "4100",
+                    "label": "ownerKey",
+                    "baseType": "string:Basic",
+                    "modelType": "naming:Descr",
+                    "needsPropDelimiters": false,
+                    "uitype": "string",
+                    "createOnly": false,
+                    "readWrite": true,
+                    "readOnly": false,
+                    "isNaming": false,
+                    "secure": false,
+                    "implicit": false,
+                    "mandatory": false,
+                    "isOverride": false,
+                    "isLike": false,
+                    "validators": [
+                         {"min" : 0, "max": 128,
+                             "regexs": [
+                                 {"regex" : "^[a-zA-Z0-9\\\\!#$%()*,-./:;@ _{|}~?&+]+$", "type": "include"}
+                             ]
+                         }
+                    ],
+                    "platformFlavors": [
+
+                    ],
+                    "isNxosConverged": false,
+                    "isDeprecated": false,
+                    "isHidden": false
+                },
+                "ownerTag": {
+                    "versions": "1.0(1e)-",
+                    "comment": [
+                         "A tag for enabling clients to add their own data. For example, to indicate who created this object."
+                    ],
+                    "isConfigurable": true,
+                    "propGlobalId": "15231",
+                    "propLocalId": "4101",
+                    "label": "ownerTag",
+                    "baseType": "string:Basic",
+                    "modelType": "naming:Descr",
+                    "needsPropDelimiters": false,
+                    "uitype": "string",
+                    "createOnly": false,
+                    "readWrite": true,
+                    "readOnly": false,
+                    "isNaming": false,
+                    "secure": false,
+                    "implicit": false,
+                    "mandatory": false,
+                    "isOverride": false,
+                    "isLike": false,
+                    "validators": [
+                         {"min" : 0, "max": 64,
+                             "regexs": [
+                                 {"regex" : "^[a-zA-Z0-9\\\\!#$%()*,-./:;@ _{|}~?&+]+$", "type": "include"}
+                             ]
+                         }
+                    ],
+                    "platformFlavors": [
+
+                    ],
+                    "isNxosConverged": false,
+                    "isDeprecated": false,
+                    "isHidden": false
+                },
+                "rn": {
+                    "versions": "1.0(1e)-",
+                    "comment": [
+                         "Identifies an object from its siblings within the context of its parent object. The distinguished name contains a sequence of relative names."
+                    ],
+                    "isConfigurable": false,
+                    "propGlobalId": "2",
+                    "propLocalId": "3",
+                    "label": "rn",
+                    "baseType": "reference:BinRN",
+                    "modelType": "reference:BinRN",
+                    "needsPropDelimiters": true,
+                    "uitype": "auto",
+                    "createOnly": false,
+                    "readWrite": false,
+                    "readOnly": true,
+                    "isNaming": false,
+                    "secure": false,
+                    "implicit": true,
+                    "mandatory": false,
+                    "isOverride": false,
+                    "isLike": false,
+                    "platformFlavors": [
+
+                    ],
+                    "isNxosConverged": false,
+                    "isDeprecated": false,
+                    "isHidden": false
+                },
+                "status": {
+                    "versions": "1.0(1e)-",
+                    "comment": [
+                         "The upgrade status. This property is for internal use only."
+                    ],
+                    "isConfigurable": false,
+                    "propGlobalId": "3",
+                    "propLocalId": "4",
+                    "label": "status",
+                    "baseType": "scalar:Bitmask32",
+                    "modelType": "mo:ModificationStatus",
+                    "needsPropDelimiters": false,
+                    "uitype": "bitmask",
+                    "createOnly": false,
+                    "readWrite": false,
+                    "readOnly": true,
+                    "isNaming": false,
+                    "secure": false,
+                    "implicit": true,
+                    "mandatory": false,
+                    "isOverride": false,
+                    "isLike": false,
+                    "validValues": [
+                         { "value": "2", "localName": "created",
+                             "platformFlavors": [
+
+                             ],
+                             "comment": [
+                                 "In a setter method: specifies that an object should be created. An error is returned if the object already exists.  \nIn the return value of a setter method: indicates that an object has been created.  \n"
+                             ],
+                             "label": "Created "},
+                         { "value": "8", "localName": "deleted",
+                             "platformFlavors": [
+
+                             ],
+                             "comment": [
+                                 "In a setter method: specifies that an object should be deleted.  \nIn the return value of a setter method: indicates that an object has been deleted.\n"
+                             ],
+                             "label": "Deleted "},
+                         { "value": "4", "localName": "modified",
+                             "platformFlavors": [
+
+                             ],
+                             "comment": [
+                                 "In a setter method: specifies that an object should be modified  \nIn the return value of a setter method: indicates that an object has been modified.\n"
+                             ],
+                             "label": "Modified "}
+                    ],
+                    "platformFlavors": [
+
+                    ],
+                    "isNxosConverged": false,
+                    "isDeprecated": false,
+                    "isHidden": false
+                },
+                "uid": {
+                    "versions": "1.0(1e)-",
+                    "comment": [
+                         "A unique identifier for this object."
+                    ],
+                    "isConfigurable": false,
+                    "propGlobalId": "8",
+                    "propLocalId": "8",
+                    "label": "uid",
+                    "baseType": "scalar:Uint16",
+                    "modelType": "scalar:Uint16",
+                    "needsPropDelimiters": false,
+                    "uitype": "auto",
+                    "createOnly": false,
+                    "readWrite": false,
+                    "readOnly": true,
+                    "isNaming": false,
+                    "secure": false,
+                    "implicit": true,
+                    "mandatory": false,
+                    "isOverride": false,
+                    "isLike": false,
+                    "platformFlavors": [
+
+                    ],
+                    "isNxosConverged": false,
+                    "isDeprecated": false,
+                    "isHidden": false
+                },
+                "userdom": {
+                    "versions": "5.0(1k)-",
+                    "isConfigurable": true,
+                    "propGlobalId": "60657",
+                    "propLocalId": "13244",
+                    "label": "userdom",
+                    "baseType": "string:Basic",
+                    "modelType": "mo:UserDomType",
+                    "needsPropDelimiters": false,
+                    "uitype": "string",
+                    "createOnly": false,
+                    "readWrite": true,
+                    "readOnly": false,
+                    "isNaming": false,
+                    "secure": false,
+                    "implicit": false,
+                    "mandatory": false,
+                    "isOverride": false,
+                    "isLike": false,
+                    "validators": [
+                         {"min" : 0, "max": 1024,
+                             "regexs": [
+                                 {"regex" : "^[a-zA-Z0-9_.:-]+$", "type": "include"}
+                             ]
+                         }
+                    ],
+                    "validValues": [
+                         { "value": "all", "localName": "defaultValue",
+                             "platformFlavors": [
+
+                             ],
+                             "label": " "}
+                    ],
+                    "default": "all",
+                    "platformFlavors": [
+
+                    ],
+                    "isNxosConverged": false,
+                    "isDeprecated": false,
+                    "isHidden": false
+                }
             }
         }
-    }
 }

--- a/gen/templates/resource_example_all_attributes.tf.tmpl
+++ b/gen/templates/resource_example_all_attributes.tf.tmpl
@@ -18,9 +18,7 @@ resource "aci_{{$.ResourceName}}" "full_example_{{getResourceName $key $.Definit
       {{- end}}
     {{- end}}
     {{- else if .IgnoreInTest}}
-  {{overwriteProperty .PkgName .SnakeCaseName $.Definitions}} = "{{.IgnoreInTestExampleValue}}"
-    {{- else if eq .ValueType "bitmask"}}{{ $bitmaskTestValue := lookupTestValue .PkgName .SnakeCaseName $.TestVars $.Definitions $.Properties}}
-  {{overwriteProperty .PkgName .SnakeCaseName $.Definitions}} = [{{range $index, $value := $bitmaskTestValue}}{{if lt $index (subtract (len $bitmaskTestValue) 1)}}"{{$value}}",{{else}}"{{$value}}"{{end}}{{end}}]
+  {{overwriteProperty .PkgName .SnakeCaseName $.Definitions}} = {{.IgnoreInTestExampleValue}}
     {{- else}}
   {{overwriteProperty .PkgName .SnakeCaseName $.Definitions}} = {{lookupTestValue .PkgName .SnakeCaseName $.TestVars $.Definitions $.Properties}}
   {{- end}}{{- end}}{{- end}}
@@ -35,7 +33,7 @@ resource "aci_{{$.ResourceName}}" "full_example_{{getResourceName $key $.Definit
           {{- break}}
           {{- end}}
         {{- else if .IgnoreInTest}}
-      {{overwriteProperty .PkgName .SnakeCaseName $.Definitions}} = "{{.IgnoreInTestExampleValue}}"
+      {{overwriteProperty .PkgName .SnakeCaseName $.Definitions}} = {{.IgnoreInTestExampleValue}}
         {{- else}}
       {{overwriteProperty .PkgName .SnakeCaseName $.Definitions}} = "{{lookupChildTestValue .PkgName $ChildResourceName .SnakeCaseName $.TestVars 0 $.Definitions}}"{{- end}}{{ end}}{{- end}}
   }
@@ -49,7 +47,7 @@ resource "aci_{{$.ResourceName}}" "full_example_{{getResourceName $key $.Definit
           {{- break}}
           {{- end}}
         {{- else if .IgnoreInTest}}
-      {{overwriteProperty .PkgName .SnakeCaseName $.Definitions}} = "{{.IgnoreInTestExampleValue}}"
+      {{overwriteProperty .PkgName .SnakeCaseName $.Definitions}} = {{.IgnoreInTestExampleValue}}
         {{- else}}
       {{overwriteProperty .PkgName .SnakeCaseName $.Definitions}} = "{{lookupChildTestValue .PkgName $ChildResourceName .SnakeCaseName $.TestVars 0 $.Definitions}}"{{- end}}{{ end}}{{- end}}
     }
@@ -69,7 +67,7 @@ resource "aci_{{$.ResourceName}}" "full_example" {
     {{- else if eq .SnakeCaseName "t_dn" }}
   {{overwriteProperty .PkgName .SnakeCaseName $.Definitions}} = {{lookupTestValue .PkgName .SnakeCaseName $.TestVars $.Definitions $.Properties | replace ".test_0.id" ".example.id"}}
     {{- else if .IgnoreInTest}}
-  {{overwriteProperty .PkgName .SnakeCaseName $.Definitions}} = "{{.IgnoreInTestExampleValue}}"
+  {{overwriteProperty .PkgName .SnakeCaseName $.Definitions}} = {{.IgnoreInTestExampleValue}}
     {{- else}}
   {{overwriteProperty .PkgName .SnakeCaseName $.Definitions}} = {{lookupTestValue .PkgName .SnakeCaseName $.TestVars $.Definitions $.Properties}}
   {{- end}}{{- end}}{{- end}}
@@ -81,7 +79,7 @@ resource "aci_{{$.ResourceName}}" "full_example" {
         {{- else if eq .SnakeCaseName "t_dn" }}{{$attributeVale := getTestTargetDn $.TestVars.child_targets $ChildResourceName "target_dn_0" true nil 0 true | replace "test_0" "example_2" }}
       target_dn = {{if containsString $attributeVale "."}}{{$attributeVale}}{{else}}"{{$attributeVale}}"{{end}}
         {{- else if .IgnoreInTest}}
-      {{overwriteProperty .PkgName .SnakeCaseName $.Definitions}} = "{{.IgnoreInTestExampleValue}}"
+      {{overwriteProperty .PkgName .SnakeCaseName $.Definitions}} = {{.IgnoreInTestExampleValue}}
         {{- else}}
       {{overwriteProperty .PkgName .SnakeCaseName $.Definitions}} = "{{lookupChildTestValue .PkgName $ChildResourceName .SnakeCaseName $.TestVars 0 $.Definitions}}"{{- end}}{{ end}}{{- end}}
   }
@@ -92,7 +90,7 @@ resource "aci_{{$.ResourceName}}" "full_example" {
         {{- else if eq .SnakeCaseName "t_dn" }}{{$attributeVale := getTestTargetDn $.TestVars.child_targets $ChildResourceName "target_dn_0" true nil 0 true | replace "test_0" "example_2" }}
       target_dn = {{if containsString $attributeVale "."}}{{$attributeVale}}{{else}}"{{$attributeVale}}"{{end}}
         {{- else if .IgnoreInTest}}
-      {{overwriteProperty .PkgName .SnakeCaseName $.Definitions}} = "{{.IgnoreInTestExampleValue}}"
+      {{overwriteProperty .PkgName .SnakeCaseName $.Definitions}} = {{.IgnoreInTestExampleValue}}
         {{- else}}
       {{overwriteProperty .PkgName .SnakeCaseName $.Definitions}} = "{{lookupChildTestValue .PkgName $ChildResourceName .SnakeCaseName $.TestVars 0 $.Definitions}}"{{- end}}{{ end}}{{- end}}
     }
@@ -115,6 +113,8 @@ resource "aci_{{$topContext.ResourceName}}" {{- if ne $formatValue.ContainedBy "
     {{- range $topContext.Properties }}
         {{- if ne .NamedPropertyClass ""}}
   {{overwriteProperty .PkgName .SnakeCaseName $.Definitions}} = aci_{{getResourceName .NamedPropertyClass $.Definitions}}.example.name
+        {{- else if .IgnoreInTest }}
+  {{overwriteProperty .PkgName .SnakeCaseName $.Definitions}} = {{.IgnoreInTestExampleValue}}
     {{- else}}
   {{overwriteProperty .PkgName .SnakeCaseName $.Definitions}} = {{lookupTestValue .PkgName .SnakeCaseName $.TestVars $.Definitions $.Properties}}
   {{- end }}

--- a/internal/provider/data_source_aci_certificate_authority.go
+++ b/internal/provider/data_source_aci_certificate_authority.go
@@ -60,7 +60,7 @@ func (d *PkiTPDataSource) Schema(ctx context.Context, req datasource.SchemaReque
 			},
 			"certificate_usage": schema.SetAttribute{
 				Computed:            true,
-				MarkdownDescription: `The certificate usage of the Certificate Authority object.`,
+				MarkdownDescription: `The usage of the Certificate Authority object which can be Web Service/Authentication (WebSvcOrAuth), Platform Experience Grid (pxGrid), or both.`,
 				ElementType:         types.StringType,
 			},
 			"description": schema.StringAttribute{

--- a/internal/provider/data_source_aci_certificate_authority.go
+++ b/internal/provider/data_source_aci_certificate_authority.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -56,6 +57,11 @@ func (d *PkiTPDataSource) Schema(ctx context.Context, req datasource.SchemaReque
 			"certificate_chain": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: `The PEM-encoded chain of trust from the trustpoint to a trusted root authority.`,
+			},
+			"certificate_usage": schema.SetAttribute{
+				Computed:            true,
+				MarkdownDescription: `The certificate usage of the Certificate Authority object.`,
+				ElementType:         types.StringType,
 			},
 			"description": schema.StringAttribute{
 				Computed:            true,

--- a/internal/provider/resource_aci_certificate_authority.go
+++ b/internal/provider/resource_aci_certificate_authority.go
@@ -189,7 +189,7 @@ func (r *PkiTPResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				MarkdownDescription: `The PEM-encoded chain of trust from the trustpoint to a trusted root authority.`,
 			},
 			"certificate_usage": schema.SetAttribute{
-				MarkdownDescription: `The certificate usage of the Certificate Authority object.`,
+				MarkdownDescription: `The usage of the Certificate Authority object which can be Web Service/Authentication (WebSvcOrAuth), Platform Experience Grid (pxGrid), or both.`,
 				Optional:            true,
 				Computed:            true,
 				PlanModifiers: []planmodifier.Set{


### PR DESCRIPTION
A new bitmask property exists in the latest version of ACI meta-data for pkiTP called certUsage.

When the meta-data is updated currently the generator fails with:

```
panic: template: :12:172: executing "" at <$.Definitions>: range can't iterate over WebSvcOrAuth

goroutine 1 [running]:
main.renderTemplate({0x1276803, 0x12}, {0xc000c60310, 0xa}, {0x12736bd, 0xe}, {0x126d5c0?, 0xc0014f7400?})
        C:/git/Terraform Project/terraform-provider-aci/gen/generator.go:569 +0xa55
main.main()
        C:/git/Terraform Project/terraform-provider-aci/gen/generator.go:934 +0xb70
exit status 2
main.go:20: running "go": exit status 1  
```

DOD:
- Fix generator to handle this new property use case
- Update pkiTP metadata and generate new code
- Out of Scope: Functioning integration tests until an updated APIC is available.