### PR TITLE
[ignore] Allow update_metadata branch to trigger CI (DCNE-252)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [master, update_metadata]
   pull_request:
 
 permissions:


### PR DESCRIPTION
PR's created by the GitHub bot don't appear to trigger the `pull_request` event for the CI.
Added a separate trigger so any pushes to the `update_metadata` runs the CI.
Hopefully this also shows up in the PR.