### PR TITLE
[ignore] Update .goreleaser following archives.format deprecation and change to formats

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@v3
       - name: Generate provider code
         run: go generate
       - name: Check generated code for diffs

--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -55,6 +55,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@v3
       - name: Generate annotation unsupported provider code
         run: go generate
         env:

--- a/.github/workflows/update-metadata.yml
+++ b/.github/workflows/update-metadata.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@v3
       - name: Get latest metadata and generate provider code
         run: go generate
         env:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,7 +33,7 @@ builds:
       goarch: '386'
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
-- format: zip
+- formats: zip
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'


### PR DESCRIPTION
Also fixes the failing CI after Terraform was removed from the `ubuntu-latest` image when GitHub updated it to Ubuntu 24.04.