### PR TITLE
[ignore] fix test for aci_management_access_policy to only be executed on supported versions (DCNE-406)

### DIFF
--- a/gen/definitions/classes.yaml
+++ b/gen/definitions/classes.yaml
@@ -1010,7 +1010,7 @@ commPol:
   sub_category: "Fabric Policies"
   ui_locations:
     - "Fabric -> Fabric Policies -> Policies -> Pod -> Management Access"
-  class_version: "6.0(2h)"
+  class_version: "6.0(2h)-6.0(8g),6.1(3f)-"
   contained_by:
       - "polUni"
   rn_prepend: "fabric"

--- a/gen/testvars/commPol.yaml
+++ b/gen/testvars/commPol.yaml
@@ -263,5 +263,5 @@ child_targets:
         name: "test_name"
 
 test_type: both
-class_version: 6.0(2h)
+class_version: 6.0(2h)-6.0(8g),6.1(3f)-
 version_mismatch: true

--- a/internal/provider/data_source_aci_management_access_policy_test.go
+++ b/internal/provider/data_source_aci_management_access_policy_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccDataSourceCommPol(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t, "both", "6.0(2h)") },
+		PreCheck:                 func() { testAccPreCheck(t, "both", "6.0(2h)-6.0(8g),6.1(3f)-") },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -104,12 +104,14 @@ func testAccPreCheck(t *testing.T, testType string, testApplicableFromVersion st
 	if err != nil {
 		t.Fatalf("Error fetching APIC controller information: %v", err)
 	}
+
 	apicVersion := extractControllerVersion(infoController)
-	// TODO process the version when it has ranges associated with it
-	if apicVersion != strings.TrimSuffix(testApplicableFromVersion, "-") {
-		if IsVersionGreater(*ParseVersion(testApplicableFromVersion).Version, *ParseVersion(apicVersion).Version) {
-			t.Skip("[WARNING] Test skipped because it is not supported on APIC version:", apicVersion)
-		}
+
+	comparisonResult, err := CompareVersionsRange(apicVersion, testApplicableFromVersion, "inside")
+	if err != nil {
+		t.Skipf("[ERROR] Test skipped because the version '%s' couldn't be checked, error: %s", testApplicableFromVersion, err)
+	} else if !comparisonResult {
+		t.Skipf("[WARNING] Test skipped because the version '%s' is not supported on APIC version: %s", testApplicableFromVersion, apicVersion)
 	}
 
 }

--- a/internal/provider/resource_aci_management_access_policy_test.go
+++ b/internal/provider/resource_aci_management_access_policy_test.go
@@ -17,7 +17,7 @@ import (
 func TestAccResourceCommPol(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t, "both", "6.0(2h)") },
+		PreCheck:                 func() { testAccPreCheck(t, "both", "6.0(2h)-6.0(8g),6.1(3f)-") },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create with minimum config and verify default APIC values
@@ -43,7 +43,7 @@ func TestAccResourceCommPol(t *testing.T) {
 
 	setEnvVariable(t, "ACI_ALLOW_EXISTING_ON_CREATE", "false")
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t, "both", "6.0(2h)") },
+		PreCheck:                 func() { testAccPreCheck(t, "both", "6.0(2h)-6.0(8g),6.1(3f)-") },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create with minimum config and verify default APIC values
@@ -56,7 +56,7 @@ func TestAccResourceCommPol(t *testing.T) {
 
 	setEnvVariable(t, "ACI_ALLOW_EXISTING_ON_CREATE", "true")
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t, "both", "6.0(2h)") },
+		PreCheck:                 func() { testAccPreCheck(t, "both", "6.0(2h)-6.0(8g),6.1(3f)-") },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create with minimum config and verify default APIC values
@@ -81,7 +81,7 @@ func TestAccResourceCommPol(t *testing.T) {
 	})
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t, "both", "6.0(2h)") },
+		PreCheck:                 func() { testAccPreCheck(t, "both", "6.0(2h)-6.0(8g),6.1(3f)-") },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create with minimum config and verify default APIC values


### PR DESCRIPTION
fixes DCNE-406