### PR TITLE
[ignore] change test values for alloc_mode of aci_vlan_pool in vmm_domain resource test to pass with validation rules blocking in aci 5.x (DCNE-711)

### DIFF
--- a/gen/definitions/properties/infraRsVlanNs.yaml
+++ b/gen/definitions/properties/infraRsVlanNs.yaml
@@ -3,10 +3,10 @@ documentation:
 targets:
     - class_name: fvnsVlanInstP
       properties:
-        alloc_mode: static
+        alloc_mode: dynamic
         name: vlan_pool_name_1
       relation_resource_name: vlan_pool
-      target_dn: uni/infra/vlanns-[vlan_pool_name_1]-static
+      target_dn: uni/infra/vlanns-[vlan_pool_name_1]-dynamic
       target_dn_ref: aci_vlan_pool.test_vlan_pool_1.id
 
 example_value_overwrite:

--- a/gen/testvars/vmmDomP.yaml
+++ b/gen/testvars/vmmDomP.yaml
@@ -243,7 +243,7 @@ child_targets:
         gateway_address: "10.0.0.1/24"
         name: "ip_address_pool_name_1"
   - class_name: "fvnsVlanInstP"
-    target_dn: "uni/infra/vlanns-[vlan_pool_name_1]-static"
+    target_dn: "uni/infra/vlanns-[vlan_pool_name_1]-dynamic"
     relation_resource_name: "vlan_pool"
     static: false
     target_dn_ref: "aci_vlan_pool.test_vlan_pool_1.id"
@@ -252,7 +252,7 @@ child_targets:
     target_resource_name: "vlan_pool"
     parent_dn_key: "parent_dn"
     properties:
-        alloc_mode: "static"
+        alloc_mode: "dynamic"
         name: "vlan_pool_name_1"
 
 test_type: both

--- a/internal/provider/resource_aci_vmm_domain_test.go
+++ b/internal/provider/resource_aci_vmm_domain_test.go
@@ -355,7 +355,7 @@ func TestAccResourceVmmDomP(t *testing.T) {
 						resource.TestCheckResourceAttr("aci_vmm_domain.test", "relation_to_vlan_pool.tags.1.key", "key_1"),
 						resource.TestCheckResourceAttr("aci_vmm_domain.test", "relation_to_vlan_pool.tags.1.value", "test_value"),
 						resource.TestCheckResourceAttr("aci_vmm_domain.test", "relation_to_vlan_pool.tags.#", "2"),
-						resource.TestCheckResourceAttr("aci_vmm_domain.test", "relation_to_vlan_pool.target_dn", "uni/infra/vlanns-[vlan_pool_name_1]-static"),
+						resource.TestCheckResourceAttr("aci_vmm_domain.test", "relation_to_vlan_pool.target_dn", "uni/infra/vlanns-[vlan_pool_name_1]-dynamic"),
 					),
 					composeAggregateTestCheckFuncWithVersion(t, "3.2(1l)-", "inside",
 						resource.TestCheckResourceAttr("aci_vmm_domain.test", "tags.0.key", "key_0"),
@@ -471,7 +471,7 @@ func TestAccResourceVmmDomP(t *testing.T) {
 						resource.TestCheckResourceAttr("aci_vmm_domain.test", "relation_to_vlan_pool.tags.1.key", "key_1"),
 						resource.TestCheckResourceAttr("aci_vmm_domain.test", "relation_to_vlan_pool.tags.1.value", "test_value"),
 						resource.TestCheckResourceAttr("aci_vmm_domain.test", "relation_to_vlan_pool.tags.#", "2"),
-						resource.TestCheckResourceAttr("aci_vmm_domain.test", "relation_to_vlan_pool.target_dn", "uni/infra/vlanns-[vlan_pool_name_1]-static"),
+						resource.TestCheckResourceAttr("aci_vmm_domain.test", "relation_to_vlan_pool.target_dn", "uni/infra/vlanns-[vlan_pool_name_1]-dynamic"),
 					),
 					composeAggregateTestCheckFuncWithVersion(t, "3.2(1l)-", "inside",
 						resource.TestCheckResourceAttr("aci_vmm_domain.test", "tags.0.key", "key_0"),
@@ -701,7 +701,7 @@ resource "aci_ip_address_pool" "test_ip_address_pool_0"{
   name = "ip_address_pool_name_1"
 }
 resource "aci_vlan_pool" "test_vlan_pool_1"{
-  alloc_mode = "static"
+  alloc_mode = "dynamic"
   name = "vlan_pool_name_1"
 }
 `


### PR DESCRIPTION
PR to fix integration test in 5.x version where static allocation could not be associated to vmm domain:

        Error: The post rest request failed

          with aci_vmm_domain.test,
          on terraform_plugin_test.tf line 21, in resource "aci_vmm_domain" "test":
          21: resource "aci_vmm_domain" "test" {

        Response Status Code: 400, Error Code: 130, Error Message: Vlan Namespace
        with static allocation mode cannot be associated to VMM Domain, Please use
        dynamic allocation mode.