### PR TITLE
[ignore] increase timeout for acceptance testing (DCNE-725)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -96,7 +96,7 @@ jobs:
           terraform_version: '1.9.*'
           terraform_wrapper: false
       - name: Terraform Acceptance Test (APIC ${{ matrix.apic_host.name }})
-        run: go test github.com/CiscoDevNet/terraform-provider-aci/v2/internal/provider -v -race -timeout 300m -coverprofile=coverage.out -covermode=atomic
+        run: go test github.com/CiscoDevNet/terraform-provider-aci/v2/internal/provider -v -race -timeout 24h -coverprofile=coverage.out -covermode=atomic
         env:
           TF_ACC: '1'
           TF_ACC_STATE_LINEAGE: '1'


### PR DESCRIPTION
Increasing timeout of acceptance test to avoid test crashes due to timeout exceeding. This is happening due to the large amount of tests in combination with the slowness of the APICs.
