### PR TITLE
[minor_change] Add explicit-failover mode to aci_lacp_policy (DCNE-811)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
-
-IMPROVEMENTS:
-- Add `explicit-failover` as a valid `mode` for the `aci_lacp_policy` resource.
-
 ## 2.19.0 (April 17, 2026)
 
 This release includes resources and data sources that have been migrated from SDKv2 to the Terraform Provider Framework. Those resources and data sources will continue to accept legacy attributes but deprecation warnings will be displayed. See the [migration guide](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/guides/migration) for more details on the migration and how to upgrade the provider to this release and any subsequent v2.x release that will include migrated resources and data sources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+IMPROVEMENTS:
+- Add `explicit-failover` as a valid `mode` for the `aci_lacp_policy` resource.
+
 ## 2.19.0 (April 17, 2026)
 
 This release includes resources and data sources that have been migrated from SDKv2 to the Terraform Provider Framework. Those resources and data sources will continue to accept legacy attributes but deprecation warnings will be displayed. See the [migration guide](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/guides/migration) for more details on the migration and how to upgrade the provider to this release and any subsequent v2.x release that will include migrated resources and data sources.

--- a/aci/resource_aci_lacplagpol.go
+++ b/aci/resource_aci_lacplagpol.go
@@ -75,6 +75,7 @@ func resourceAciLACPPolicy() *schema.Resource {
 					"passive",
 					"mac-pin",
 					"mac-pin-nicload",
+					"explicit-failover",
 				}, false),
 			},
 

--- a/docs/resources/lacp_policy.md
+++ b/docs/resources/lacp_policy.md
@@ -36,7 +36,7 @@ resource "aci_lacp_policy" "example" {
 - `ctrl` - (Optional) List of LAG control properties. Allowed values are "symmetric-hash", "susp-individual", "graceful-conv", "load-defer" and "fast-sel-hot-stdby". default value is \["fast-sel-hot-stdby", "graceful-conv", "susp-individual"\]
 - `max_links` - (Optional) Maximum number of links. Allowed value range is "1" - "16". Default is "16".
 - `min_links` - (Optional) Minimum number of links in port channel. Allowed value range is "1" - "16". Default is "1".
-- `mode` - (Optional) policy mode. Allowed values are "off", "active", "passive", "mac-pin" and "mac-pin-nicload". Default is "off".
+- `mode` - (Optional) policy mode. Allowed values are "off", "active", "passive", "mac-pin", "mac-pin-nicload" and "explicit-failover". Default is "off".
 - `name_alias` - (Optional) Name alias for object LACP Policy.
 
 ## Attribute Reference

--- a/legacy-docs/docs/r/lacp_policy.html.markdown
+++ b/legacy-docs/docs/r/lacp_policy.html.markdown
@@ -36,7 +36,7 @@ resource "aci_lacp_policy" "example" {
 - `ctrl` - (Optional) List of LAG control properties. Allowed values are "symmetric-hash", "susp-individual", "graceful-conv", "load-defer" and "fast-sel-hot-stdby". default value is \["fast-sel-hot-stdby", "graceful-conv", "susp-individual"\]
 - `max_links` - (Optional) Maximum number of links. Allowed value range is "1" - "16". Default is "16".
 - `min_links` - (Optional) Minimum number of links in port channel. Allowed value range is "1" - "16". Default is "1".
-- `mode` - (Optional) policy mode. Allowed values are "off", "active", "passive", "mac-pin" and "mac-pin-nicload". Default is "off".
+- `mode` - (Optional) policy mode. Allowed values are "off", "active", "passive", "mac-pin", "mac-pin-nicload" and "explicit-failover". Default is "off".
 - `name_alias` - (Optional) Name alias for object LACP Policy.
 
 ## Attribute Reference


### PR DESCRIPTION
## Summary

- Add `explicit-failover` as a valid `mode` for the `aci_lacp_policy` resource (`lacpLagPol`)
- Update validation in resource schema, CHANGELOG, and both current and legacy documentation
- This mode configures a port channel in active/standby where only one link forwards traffic at a time, with deterministic failover to the standby link

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-opus-4-6
- **AI Contribution**: ~90%
- **AI Reason**: add explicit-failover mode to lacpLagPol validation, docs, and changelog
- **Human Oversight**: Code reviewed and approved by @ChristopherJHart