### PR TITLE
[bugfix] fix for migration type issue of arp_learning in vmm_domain resource (DCNE-837)

### DIFF
--- a/gen/templates/resource.go.tmpl
+++ b/gen/templates/resource.go.tmpl
@@ -191,7 +191,7 @@ var deprecated{{ capitalize .ClassName }}Type = types.ObjectType{
 
 type {{.ResourceClassName}}ResourceModelV{{.LegacySchemaVersion}} struct {
 	{{- range .LegacyAttributes}}
-	{{ .Name }} {{ if .StaticCustomType}} customTypes.{{.StaticCustomType}}StringValue{{else}}types.{{getMigrationType .ValueType}}{{ end}} `tfsdk:"{{.AttributeName}}"`
+	{{ .Name }} {{ if and .StaticCustomType (ne .StaticCustomType "VMMArpLearning")}} customTypes.{{.StaticCustomType}}StringValue{{else}}types.{{getMigrationType .ValueType}}{{ end}} `tfsdk:"{{.AttributeName}}"`
 	{{- end }}
 	{{- range .LegacyBlocks}}
 	{{ capitalize .ClassName }} types.Set `tfsdk:"{{.Name}}"`
@@ -299,7 +299,7 @@ func (r *{{.ResourceClassName}}Resource) UpgradeState(ctx context.Context) map[i
 					{{- range .Properties}}
 						{{- if isLegacyAttribute .Name $.LegacyAttributes}}{{$LegacyAttribute := getLegacyAttribute .Name $.LegacyAttributes}}
 							{{- if .HasCustomType}}
-					{{ .Name }}: customTypes.{{- if .StaticCustomType}}{{.StaticCustomType}}StringValue{ StringValue: basetypes.NewStringValue(priorStateData.{{ .Name }}.NamedValueString()){{else}}{{.ResourceClassName}}{{.Name}}StringValue{ StringValue: priorStateData.{{ .Name }}{{- end}} },
+					{{ .Name }}: customTypes.{{- if .StaticCustomType}}{{.StaticCustomType}}StringValue{ StringValue: basetypes.NewStringValue(priorStateData.{{ .Name }}.{{ if ne .StaticCustomType "VMMArpLearning"}}Named{{end}}ValueString()){{else}}{{.ResourceClassName}}{{.Name}}StringValue{ StringValue: priorStateData.{{ .Name }}{{- end}} },
 							{{- else if ne (getMigrationType $LegacyAttribute.ValueType) "List"}}
 					{{ .Name }}: priorStateData.{{ .Name }},
 							{{- end}}

--- a/internal/provider/resource_aci_vmm_domain.go
+++ b/internal/provider/resource_aci_vmm_domain.go
@@ -754,40 +754,40 @@ type VmmDomPIdentifier struct {
 }
 
 type VmmDomPResourceModelV1 struct {
-	AccessMode                                   types.String                          `tfsdk:"access_mode"`
-	Annotation                                   types.String                          `tfsdk:"annotation"`
-	ArpLearning                                  customTypes.VMMArpLearningStringValue `tfsdk:"arp_learning"`
-	AveTimeOut                                   types.String                          `tfsdk:"ave_time_out"`
-	ConfigInfraPg                                types.String                          `tfsdk:"config_infra_pg"`
-	CtrlKnob                                     types.String                          `tfsdk:"ctrl_knob"`
-	Delimiter                                    types.String                          `tfsdk:"delimiter"`
-	EnableAVE                                    types.String                          `tfsdk:"enable_ave"`
-	EnableTag                                    types.String                          `tfsdk:"enable_tag"`
-	EnableVmFolder                               types.String                          `tfsdk:"enable_vm_folder"`
-	EncapMode                                    types.String                          `tfsdk:"encap_mode"`
-	EnfPref                                      types.String                          `tfsdk:"enf_pref"`
-	EpInventoryType                              types.String                          `tfsdk:"ep_inventory_type"`
-	EpRetTime                                    types.String                          `tfsdk:"ep_ret_time"`
-	HvAvailMonitor                               types.String                          `tfsdk:"hv_avail_monitor"`
-	Id                                           types.String                          `tfsdk:"id"`
-	McastAddr                                    types.String                          `tfsdk:"mcast_addr"`
-	Mode                                         types.String                          `tfsdk:"mode"`
-	Name                                         types.String                          `tfsdk:"name"`
-	NameAlias                                    types.String                          `tfsdk:"name_alias"`
-	ParentDn                                     types.String                          `tfsdk:"provider_profile_dn"`
-	PrefEncapMode                                types.String                          `tfsdk:"pref_encap_mode"`
-	Ignored_relation_infra_rs_dom_vxlan_ns_def   types.String                          `tfsdk:"relation_infra_rs_dom_vxlan_ns_def"`
-	Ignored_relation_infra_rs_vlan_ns_def        types.String                          `tfsdk:"relation_infra_rs_vlan_ns_def"`
-	InfraRsVipAddrNs                             types.String                          `tfsdk:"relation_infra_rs_vip_addr_ns"`
-	VmmRsPrefEnhancedLagPol                      types.String                          `tfsdk:"relation_vmm_rs_pref_enhanced_lag_pol"`
-	VmmRsDomMcastAddrNs                          types.String                          `tfsdk:"relation_vmm_rs_dom_mcast_addr_ns"`
-	InfraRsVlanNs                                types.String                          `tfsdk:"relation_infra_rs_vlan_ns"`
-	Ignored_relation_vmm_rs_default_cdp_if_pol   types.String                          `tfsdk:"relation_vmm_rs_default_cdp_if_pol"`
-	Ignored_relation_vmm_rs_default_fw_pol       types.String                          `tfsdk:"relation_vmm_rs_default_fw_pol"`
-	Ignored_relation_vmm_rs_default_l2_inst_pol  types.String                          `tfsdk:"relation_vmm_rs_default_l2_inst_pol"`
-	Ignored_relation_vmm_rs_default_lacp_lag_pol types.String                          `tfsdk:"relation_vmm_rs_default_lacp_lag_pol"`
-	Ignored_relation_vmm_rs_default_lldp_if_pol  types.String                          `tfsdk:"relation_vmm_rs_default_lldp_if_pol"`
-	Ignored_relation_vmm_rs_default_stp_if_pol   types.String                          `tfsdk:"relation_vmm_rs_default_stp_if_pol"`
+	AccessMode                                   types.String `tfsdk:"access_mode"`
+	Annotation                                   types.String `tfsdk:"annotation"`
+	ArpLearning                                  types.String `tfsdk:"arp_learning"`
+	AveTimeOut                                   types.String `tfsdk:"ave_time_out"`
+	ConfigInfraPg                                types.String `tfsdk:"config_infra_pg"`
+	CtrlKnob                                     types.String `tfsdk:"ctrl_knob"`
+	Delimiter                                    types.String `tfsdk:"delimiter"`
+	EnableAVE                                    types.String `tfsdk:"enable_ave"`
+	EnableTag                                    types.String `tfsdk:"enable_tag"`
+	EnableVmFolder                               types.String `tfsdk:"enable_vm_folder"`
+	EncapMode                                    types.String `tfsdk:"encap_mode"`
+	EnfPref                                      types.String `tfsdk:"enf_pref"`
+	EpInventoryType                              types.String `tfsdk:"ep_inventory_type"`
+	EpRetTime                                    types.String `tfsdk:"ep_ret_time"`
+	HvAvailMonitor                               types.String `tfsdk:"hv_avail_monitor"`
+	Id                                           types.String `tfsdk:"id"`
+	McastAddr                                    types.String `tfsdk:"mcast_addr"`
+	Mode                                         types.String `tfsdk:"mode"`
+	Name                                         types.String `tfsdk:"name"`
+	NameAlias                                    types.String `tfsdk:"name_alias"`
+	ParentDn                                     types.String `tfsdk:"provider_profile_dn"`
+	PrefEncapMode                                types.String `tfsdk:"pref_encap_mode"`
+	Ignored_relation_infra_rs_dom_vxlan_ns_def   types.String `tfsdk:"relation_infra_rs_dom_vxlan_ns_def"`
+	Ignored_relation_infra_rs_vlan_ns_def        types.String `tfsdk:"relation_infra_rs_vlan_ns_def"`
+	InfraRsVipAddrNs                             types.String `tfsdk:"relation_infra_rs_vip_addr_ns"`
+	VmmRsPrefEnhancedLagPol                      types.String `tfsdk:"relation_vmm_rs_pref_enhanced_lag_pol"`
+	VmmRsDomMcastAddrNs                          types.String `tfsdk:"relation_vmm_rs_dom_mcast_addr_ns"`
+	InfraRsVlanNs                                types.String `tfsdk:"relation_infra_rs_vlan_ns"`
+	Ignored_relation_vmm_rs_default_cdp_if_pol   types.String `tfsdk:"relation_vmm_rs_default_cdp_if_pol"`
+	Ignored_relation_vmm_rs_default_fw_pol       types.String `tfsdk:"relation_vmm_rs_default_fw_pol"`
+	Ignored_relation_vmm_rs_default_l2_inst_pol  types.String `tfsdk:"relation_vmm_rs_default_l2_inst_pol"`
+	Ignored_relation_vmm_rs_default_lacp_lag_pol types.String `tfsdk:"relation_vmm_rs_default_lacp_lag_pol"`
+	Ignored_relation_vmm_rs_default_lldp_if_pol  types.String `tfsdk:"relation_vmm_rs_default_lldp_if_pol"`
+	Ignored_relation_vmm_rs_default_stp_if_pol   types.String `tfsdk:"relation_vmm_rs_default_stp_if_pol"`
 }
 
 func (r *VmmDomPResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
@@ -982,7 +982,7 @@ func (r *VmmDomPResource) UpgradeState(ctx context.Context) map[int64]resource.S
 					ParentDn:                  priorStateData.ParentDn,
 					AccessMode:                priorStateData.AccessMode,
 					Annotation:                priorStateData.Annotation,
-					ArpLearning:               customTypes.VMMArpLearningStringValue{StringValue: basetypes.NewStringValue(priorStateData.ArpLearning.NamedValueString())},
+					ArpLearning:               customTypes.VMMArpLearningStringValue{StringValue: basetypes.NewStringValue(priorStateData.ArpLearning.ValueString())},
 					AveTimeOut:                priorStateData.AveTimeOut,
 					ConfigInfraPg:             priorStateData.ConfigInfraPg,
 					CtrlKnob:                  priorStateData.CtrlKnob,


### PR DESCRIPTION
The migration of vmmDomain was failing due to incorrect type migration of previous schema version to new schema version.  This new type was introduced because APIC returns incorrect value for disabled (sets "" for disabled), and plugin framework requires (semantic) equality of the value.

2bfe616ef5fb:/terraform-provider-aci# go test ./internal/provider/ -v -race -run TestAccResourceVmmDomP
=== RUN   TestAccResourceVmmDomP
--- PASS: TestAccResourceVmmDomP (157.52s)
PASS
ok      github.com/CiscoDevNet/terraform-provider-aci/v2/internal/provider      158.570s
2bfe616ef5fb:/terraform-provider-aci# go test ./internal/provider/ -v -race -run TestAccDataSourceVmmDomP
=== RUN   TestAccDataSourceVmmDomP
--- PASS: TestAccDataSourceVmmDomP (16.23s)
PASS