### PR TITLE
[bugfix] ensure path starts with a single slash to assure signature is created correctly for key based authentication (DCNE-838)

### DIFF
--- a/gen/templates/provider.go.tmpl
+++ b/gen/templates/provider.go.tmpl
@@ -359,7 +359,7 @@ func (p *AciProvider) Functions(ctx context.Context) []func() function.Function 
 }
 
 func getVersionAPIC(ctx context.Context, diags *diag.Diagnostics, client *client.Client) string {
-	requestData := DoRestRequest(ctx, diags, client, "/api/node/class/topSystem.json?query-target-filter=eq(topSystem.role,\"controller\")", "GET", nil)
+	requestData := DoRestRequest(ctx, diags, client, "api/node/class/topSystem.json?query-target-filter=eq(topSystem.role,\"controller\")", "GET", nil)
 	if diags.HasError() {
 		return ""
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -602,7 +602,7 @@ func (p *AciProvider) Functions(ctx context.Context) []func() function.Function 
 }
 
 func getVersionAPIC(ctx context.Context, diags *diag.Diagnostics, client *client.Client) string {
-	requestData := DoRestRequest(ctx, diags, client, "/api/node/class/topSystem.json?query-target-filter=eq(topSystem.role,\"controller\")", "GET", nil)
+	requestData := DoRestRequest(ctx, diags, client, "api/node/class/topSystem.json?query-target-filter=eq(topSystem.role,\"controller\")", "GET", nil)
 	if diags.HasError() {
 		return ""
 	}

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -88,10 +88,10 @@ func CheckDn(ctx context.Context, diags *diag.Diagnostics, client *client.Client
 
 func DoRestRequestEscapeHtml(ctx context.Context, diags *diag.Diagnostics, aciClient *client.Client, path, method string, payload *container.Container, escapeHtml bool) *container.Container {
 
-	// Ensure path starts with a slash to assure signature is created correctly
-	if !strings.HasPrefix("/", path) {
-		path = fmt.Sprintf("/%s", path)
-	}
+	// Ensure path starts with exactly one leading slash so the signed content
+	// matches the URL APIC receives (the vendor client also collapses leading
+	// slashes when building the request URL, but signs the path as given).
+	path = "/" + strings.TrimLeft(path, "/")
 	var restRequest *http.Request
 	var err error
 	if escapeHtml {


### PR DESCRIPTION
fixes (DCNE-838)
