### PR TITLE
Update release workflows (DCNE-864)

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -1,16 +1,18 @@
 name: release_pr
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   release-pr:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: develop
       - name: Unshallow
         run: git fetch --prune --unshallow
 
@@ -82,7 +84,7 @@ jobs:
         run: git checkout -b release_pr && git push --set-upstream origin release_pr --force && git clean -f -d
 
       # Create or update release PR
-      - run: gh pr create --base main --head release_pr --title "Pre-Release PR (${{ steps.vars.outputs.version }})" --body ""
+      - run: gh pr create --base develop --head release_pr --title "Pre-Release PR (${{ steps.vars.outputs.version }})" --body ""
         id: pr
         continue-on-error: true
         env:

--- a/.github/workflows/sync_main.yml
+++ b/.github/workflows/sync_main.yml
@@ -1,0 +1,24 @@
+name: sync_main
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - develop
+
+jobs:
+  sync-main:
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'release_pr'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.DCNE_AUTO_TOKEN }}
+          fetch-depth: 0
+
+      - name: Fast-forward main to develop
+        run: git push origin refs/heads/develop:refs/heads/main


### PR DESCRIPTION
- Instead of this triggering on merges to main it now requires a manual run when the release is ready to draft.
- It also adds a main sync workflow that keeps main up to date with the latest release commit. 