### PR TITLE
[bugfix] fix for migration type issue of IPAddressStringValue in aci_bridge_domain resource (DCNE-930)

### DIFF
--- a/gen/templates/resource.go.tmpl
+++ b/gen/templates/resource.go.tmpl
@@ -191,7 +191,7 @@ var deprecated{{ capitalize .ClassName }}Type = types.ObjectType{
 
 type {{.ResourceClassName}}ResourceModelV{{.LegacySchemaVersion}} struct {
 	{{- range .LegacyAttributes}}
-	{{ .Name }} {{ if and .StaticCustomType (ne .StaticCustomType "VMMArpLearning")}} customTypes.{{.StaticCustomType}}StringValue{{else}}types.{{getMigrationType .ValueType}}{{ end}} `tfsdk:"{{.AttributeName}}"`
+	{{ .Name }} types.{{getMigrationType .ValueType}} `tfsdk:"{{.AttributeName}}"`
 	{{- end }}
 	{{- range .LegacyBlocks}}
 	{{ capitalize .ClassName }} types.Set `tfsdk:"{{.Name}}"`
@@ -201,7 +201,7 @@ type {{.ResourceClassName}}ResourceModelV{{.LegacySchemaVersion}} struct {
 	{{ range .LegacyBlocks}}
 type {{ capitalize .ClassName }}{{$.ResourceClassName}}ResourceModelV{{$.LegacySchemaVersion}} struct {
 		{{- range .Attributes}}
-	{{ .Name }} {{ if .StaticCustomType}} customTypes.{{.StaticCustomType}}StringValue{{else}}types.{{getMigrationType .ValueType}}{{ end}} `tfsdk:"{{.AttributeName}}"`
+	{{ .Name }} types.{{getMigrationType .ValueType}} `tfsdk:"{{.AttributeName}}"`
 		{{- end}}
 }
 
@@ -299,7 +299,7 @@ func (r *{{.ResourceClassName}}Resource) UpgradeState(ctx context.Context) map[i
 					{{- range .Properties}}
 						{{- if isLegacyAttribute .Name $.LegacyAttributes}}{{$LegacyAttribute := getLegacyAttribute .Name $.LegacyAttributes}}
 							{{- if .HasCustomType}}
-					{{ .Name }}: customTypes.{{- if .StaticCustomType}}{{.StaticCustomType}}StringValue{ StringValue: basetypes.NewStringValue(priorStateData.{{ .Name }}.{{ if ne .StaticCustomType "VMMArpLearning"}}Named{{end}}ValueString()){{else}}{{.ResourceClassName}}{{.Name}}StringValue{ StringValue: priorStateData.{{ .Name }}{{- end}} },
+					{{ .Name }}: customTypes.{{- if .StaticCustomType}}{{.StaticCustomType}}StringValue{ StringValue: basetypes.NewStringValue(priorStateData.{{ .Name }}.ValueString()){{else}}{{.ResourceClassName}}{{.Name}}StringValue{ StringValue: priorStateData.{{ .Name }}{{- end}} },
 							{{- else if ne (getMigrationType $LegacyAttribute.ValueType) "List"}}
 					{{ .Name }}: priorStateData.{{ .Name }},
 							{{- end}}
@@ -312,7 +312,11 @@ func (r *{{.ResourceClassName}}Resource) UpgradeState(ctx context.Context) map[i
 					{{- range .LegacyAttributes}}
 						{{- if ne .ReplacedBy.AttributeName "" }}
 							{{- if eq (getMigrationType .ValueType) "String"}}
+								{{- if .StaticCustomType}}
+					Deprecated{{ .Name }}: customTypes.{{.StaticCustomType}}StringValue{ StringValue: basetypes.NewStringValue(priorStateData.{{ .Name }}.ValueString()) },
+								{{- else}}
 					Deprecated{{ .Name }}: priorStateData.{{ .Name }},
+								{{- end}}
 							{{- end }}
 						{{- else if containsString .Name .AttributeName}}
 					{{ .Name }}: priorStateData.{{ .Name }},

--- a/internal/provider/resource_aci_bridge_domain.go
+++ b/internal/provider/resource_aci_bridge_domain.go
@@ -1455,44 +1455,44 @@ var deprecatedFvRsBDToNetflowMonitorPolType = types.ObjectType{
 }
 
 type FvBDResourceModelV1 struct {
-	Annotation                           types.String                     `tfsdk:"annotation"`
-	ArpFlood                             types.String                     `tfsdk:"arp_flood"`
-	Descr                                types.String                     `tfsdk:"description"`
-	EpClear                              types.String                     `tfsdk:"ep_clear"`
-	EpMoveDetectMode                     types.String                     `tfsdk:"ep_move_detect_mode"`
-	HostBasedRouting                     types.String                     `tfsdk:"host_based_routing"`
-	Id                                   types.String                     `tfsdk:"id"`
-	IntersiteBumTrafficAllow             types.String                     `tfsdk:"intersite_bum_traffic_allow"`
-	IntersiteL2Stretch                   types.String                     `tfsdk:"intersite_l2_stretch"`
-	IpLearning                           types.String                     `tfsdk:"ip_learning"`
-	Ipv6McastAllow                       types.String                     `tfsdk:"ipv6_mcast_allow"`
-	LimitIpLearnToSubnets                types.String                     `tfsdk:"limit_ip_learn_to_subnets"`
-	LlAddr                               customTypes.IPAddressStringValue `tfsdk:"ll_addr"`
-	Mac                                  types.String                     `tfsdk:"mac"`
-	McastAllow                           types.String                     `tfsdk:"mcast_allow"`
-	MultiDstPktAct                       types.String                     `tfsdk:"multi_dst_pkt_act"`
-	Name                                 types.String                     `tfsdk:"name"`
-	NameAlias                            types.String                     `tfsdk:"name_alias"`
-	OptimizeWanBandwidth                 types.String                     `tfsdk:"optimize_wan_bandwidth"`
-	ParentDn                             types.String                     `tfsdk:"tenant_dn"`
-	Type                                 types.String                     `tfsdk:"bridge_domain_type"`
-	UnicastRoute                         types.String                     `tfsdk:"unicast_route"`
-	UnkMacUcastAct                       types.String                     `tfsdk:"unk_mac_ucast_act"`
-	UnkMcastAct                          types.String                     `tfsdk:"unk_mcast_act"`
-	V6unkMcastAct                        types.String                     `tfsdk:"v6unk_mcast_act"`
-	Vmac                                 types.String                     `tfsdk:"vmac"`
-	FvRsBDToRelayP                       types.String                     `tfsdk:"relation_fv_rs_bd_to_relay_p"`
-	FvRsBdToEpRet                        types.String                     `tfsdk:"relation_fv_rs_bd_to_ep_ret"`
-	FvRsBDToFhs                          types.String                     `tfsdk:"relation_fv_rs_bd_to_fhs"`
-	FvRsBDToOut                          types.Set                        `tfsdk:"relation_fv_rs_bd_to_out"`
-	FvRsABDPolMonPol                     types.String                     `tfsdk:"relation_fv_rs_abd_pol_mon_pol"`
-	FvRsBDToNdP                          types.String                     `tfsdk:"relation_fv_rs_bd_to_nd_p"`
-	Ignored_relation_fv_rs_bd_flood_to   types.Set                        `tfsdk:"relation_fv_rs_bd_flood_to"`
-	Ignored_relation_fv_rs_bd_to_profile types.String                     `tfsdk:"relation_fv_rs_bd_to_profile"`
-	FvRsIgmpsn                           types.String                     `tfsdk:"relation_fv_rs_igmpsn"`
-	FvRsMldsn                            types.String                     `tfsdk:"relation_fv_rs_mldsn"`
-	FvRsCtx                              types.String                     `tfsdk:"relation_fv_rs_ctx"`
-	FvRsBDToNetflowMonitorPol            types.Set                        `tfsdk:"relation_fv_rs_bd_to_netflow_monitor_pol"`
+	Annotation                           types.String `tfsdk:"annotation"`
+	ArpFlood                             types.String `tfsdk:"arp_flood"`
+	Descr                                types.String `tfsdk:"description"`
+	EpClear                              types.String `tfsdk:"ep_clear"`
+	EpMoveDetectMode                     types.String `tfsdk:"ep_move_detect_mode"`
+	HostBasedRouting                     types.String `tfsdk:"host_based_routing"`
+	Id                                   types.String `tfsdk:"id"`
+	IntersiteBumTrafficAllow             types.String `tfsdk:"intersite_bum_traffic_allow"`
+	IntersiteL2Stretch                   types.String `tfsdk:"intersite_l2_stretch"`
+	IpLearning                           types.String `tfsdk:"ip_learning"`
+	Ipv6McastAllow                       types.String `tfsdk:"ipv6_mcast_allow"`
+	LimitIpLearnToSubnets                types.String `tfsdk:"limit_ip_learn_to_subnets"`
+	LlAddr                               types.String `tfsdk:"ll_addr"`
+	Mac                                  types.String `tfsdk:"mac"`
+	McastAllow                           types.String `tfsdk:"mcast_allow"`
+	MultiDstPktAct                       types.String `tfsdk:"multi_dst_pkt_act"`
+	Name                                 types.String `tfsdk:"name"`
+	NameAlias                            types.String `tfsdk:"name_alias"`
+	OptimizeWanBandwidth                 types.String `tfsdk:"optimize_wan_bandwidth"`
+	ParentDn                             types.String `tfsdk:"tenant_dn"`
+	Type                                 types.String `tfsdk:"bridge_domain_type"`
+	UnicastRoute                         types.String `tfsdk:"unicast_route"`
+	UnkMacUcastAct                       types.String `tfsdk:"unk_mac_ucast_act"`
+	UnkMcastAct                          types.String `tfsdk:"unk_mcast_act"`
+	V6unkMcastAct                        types.String `tfsdk:"v6unk_mcast_act"`
+	Vmac                                 types.String `tfsdk:"vmac"`
+	FvRsBDToRelayP                       types.String `tfsdk:"relation_fv_rs_bd_to_relay_p"`
+	FvRsBdToEpRet                        types.String `tfsdk:"relation_fv_rs_bd_to_ep_ret"`
+	FvRsBDToFhs                          types.String `tfsdk:"relation_fv_rs_bd_to_fhs"`
+	FvRsBDToOut                          types.Set    `tfsdk:"relation_fv_rs_bd_to_out"`
+	FvRsABDPolMonPol                     types.String `tfsdk:"relation_fv_rs_abd_pol_mon_pol"`
+	FvRsBDToNdP                          types.String `tfsdk:"relation_fv_rs_bd_to_nd_p"`
+	Ignored_relation_fv_rs_bd_flood_to   types.Set    `tfsdk:"relation_fv_rs_bd_flood_to"`
+	Ignored_relation_fv_rs_bd_to_profile types.String `tfsdk:"relation_fv_rs_bd_to_profile"`
+	FvRsIgmpsn                           types.String `tfsdk:"relation_fv_rs_igmpsn"`
+	FvRsMldsn                            types.String `tfsdk:"relation_fv_rs_mldsn"`
+	FvRsCtx                              types.String `tfsdk:"relation_fv_rs_ctx"`
+	FvRsBDToNetflowMonitorPol            types.Set    `tfsdk:"relation_fv_rs_bd_to_netflow_monitor_pol"`
 }
 
 type FvRsBDToNetflowMonitorPolFvBDResourceModelV1 struct {
@@ -1744,7 +1744,7 @@ func (r *FvBDResource) UpgradeState(ctx context.Context) map[int64]resource.Stat
 					IpLearning:                           priorStateData.IpLearning,
 					Ipv6McastAllow:                       priorStateData.Ipv6McastAllow,
 					LimitIpLearnToSubnets:                priorStateData.LimitIpLearnToSubnets,
-					LlAddr:                               customTypes.IPAddressStringValue{StringValue: basetypes.NewStringValue(priorStateData.LlAddr.NamedValueString())},
+					LlAddr:                               customTypes.IPAddressStringValue{StringValue: basetypes.NewStringValue(priorStateData.LlAddr.ValueString())},
 					Mac:                                  priorStateData.Mac,
 					McastARPDrop:                         basetypes.NewStringNull(),
 					McastAllow:                           priorStateData.McastAllow,
@@ -1769,7 +1769,7 @@ func (r *FvBDResource) UpgradeState(ctx context.Context) map[int64]resource.Stat
 					DeprecatedHostBasedRouting:           priorStateData.HostBasedRouting,
 					DeprecatedIntersiteBumTrafficAllow:   priorStateData.IntersiteBumTrafficAllow,
 					DeprecatedIpv6McastAllow:             priorStateData.Ipv6McastAllow,
-					DeprecatedLlAddr:                     priorStateData.LlAddr,
+					DeprecatedLlAddr:                     customTypes.IPAddressStringValue{StringValue: basetypes.NewStringValue(priorStateData.LlAddr.ValueString())},
 					DeprecatedMac:                        priorStateData.Mac,
 					DeprecatedMcastAllow:                 priorStateData.McastAllow,
 					DeprecatedMultiDstPktAct:             priorStateData.MultiDstPktAct,


### PR DESCRIPTION
DCNE-930

fixes #1492 

```
go test ./internal/provider -run '^TestAccResourceFvBDWithFvTenant$' -count=1 -v -timeout 30m
=== RUN   TestAccResourceFvBDWithFvTenant
--- PASS: TestAccResourceFvBDWithFvTenant (150.99s)
PASS
ok      github.com/CiscoDevNet/terraform-provider-aci/v2/internal/provider      151.026s

go test ./internal/provider -run '^TestAccResourceFvBDWithFvTenant$'  -count=1 -v -timeout 30m
=== RUN   TestAccResourceFvBDWithFvTenant
    provider_test.go:137: [WARNING] Test for checking the resource attribute value skipped due to version incompatibility between Property version: 1.0(1e)-6.1(1e) and APIC version: 6.2(2e).
    provider_test.go:137: [WARNING] Test for checking the resource attribute value skipped due to version incompatibility between Property version: 1.0(1e)-6.1(1e) and APIC version: 6.2(2e).
    provider_test.go:137: [WARNING] Test for checking the resource attribute value skipped due to version incompatibility between Property version: 1.0(1e)-6.1(1e) and APIC version: 6.2(2e).
--- PASS: TestAccResourceFvBDWithFvTenant (181.42s)
PASS
ok      github.com/CiscoDevNet/terraform-provider-aci/v2/internal/provider      181.431s

go test ./internal/provider -run '^TestAccResourceFvBDWithFvTenant$'  -count=1 -v -timeout 30m
=== RUN   TestAccResourceFvBDWithFvTenant
    provider_test.go:137: [WARNING] Test for checking the resource attribute value skipped due to version incompatibility between Property version: 1.0(1e)-6.1(1e) and APIC version: 6.1(5e).
    provider_test.go:137: [WARNING] Test for checking the resource attribute value skipped due to version incompatibility between Property version: 1.0(1e)-6.1(1e) and APIC version: 6.1(5e).
    provider_test.go:137: [WARNING] Test for checking the resource attribute value skipped due to version incompatibility between Property version: 1.0(1e)-6.1(1e) and APIC version: 6.1(5e).
--- PASS: TestAccResourceFvBDWithFvTenant (145.76s)
PASS
ok      github.com/CiscoDevNet/terraform-provider-aci/v2/internal/provider      145.802s